### PR TITLE
Corrections and improvements to Link component

### DIFF
--- a/src/components/Link/Link.less
+++ b/src/components/Link/Link.less
@@ -1,11 +1,5 @@
 @import (reference) '/src/assets/styles/_shared.less';
 
-.a-link {
-  &.list-link {
-    border-bottom-width: 1px;
-  }
-}
-
 .a-link__icon-after-text svg {
   margin-left: 0.25em;
 }

--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -45,11 +45,11 @@ export const WithIcon: Story = {
   args: {
     ...Default.args,
     hasIcon: true,
-    type: 'list'
+    type: 'default'
   },
   render: arguments_ => (
     <Link {...arguments_}>
-      <LinkText>Document link</LinkText> <Icon name='document' />
+      <LinkText>Download file</LinkText> <Icon name='download' />
     </Link>
   )
 };

--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -1,5 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Icon, Link, LinkText } from '~/src/index';
+import {
+  DestructiveLink,
+  Icon,
+  Link,
+  LinkText,
+  List,
+  ListLink as ListLinkComponent
+} from '~/src/index';
 
 const meta: Meta<typeof Link> = {
   component: Link,
@@ -29,16 +36,20 @@ export const Default: Story = {
 
 export const ListLink: Story = {
   args: {
-    ...Default.args,
-    type: 'list'
-  }
+    ...Default.args
+  },
+  render: arguments_ => (
+    <List isLinks>
+      <ListLinkComponent {...arguments_} />
+    </List>
+  )
 };
 
 export const Destructive: Story = {
   args: {
-    ...Default.args,
-    type: 'destructive'
-  }
+    ...Default.args
+  },
+  render: arguments_ => <DestructiveLink {...arguments_} />
 };
 
 export const WithIcon: Story = {

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -2,7 +2,7 @@ import classnames from 'classnames';
 import type { JSXElement } from '../../types/jsxElement';
 import './Link.less';
 
-interface LinkProperties {
+interface LinkProperties extends React.HTMLProps<HTMLAnchorElement> {
   type?: 'default' | 'destructive' | 'list';
   hasIcon?: boolean;
   noWrap?: boolean;
@@ -18,9 +18,12 @@ export default function Link({
   isJump = false,
   isJumpLeft = false,
   ...others
-}: LinkProperties & React.HTMLProps<HTMLAnchorElement>): JSXElement {
-  const cname = ['a-link', others.className];
-  if (type === 'list') cname.push('list-link');
+}: LinkProperties): JSXElement {
+  const cname = [others.className];
+
+  if (type === 'list') cname.push('m-list_link');
+  else cname.push('a-link');
+
   if (type === 'destructive') cname.push('a-btn a-btn__link a-btn__warning');
   if (hasIcon) cname.push('a-link__icon');
   if (noWrap) cname.push('a-link__no-wrap');

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -22,8 +22,11 @@ export default function Link({
 }: LinkProperties): JSXElement {
   const cname = [others.className];
 
-  if (type === 'list') cname.push('m-list_link');
-  else cname.push('a-link');
+  if (type === 'list') {
+    cname.push('m-list_link');
+  } else {
+    cname.push('a-link');
+  }
 
   if (type === 'destructive') cname.push('a-btn a-btn__link a-btn__warning');
   if (hasIcon) cname.push('a-link__icon');

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,5 +1,6 @@
 import classnames from 'classnames';
 import type { JSXElement } from '../../types/jsxElement';
+import ListItem from '../List/ListItem';
 import './Link.less';
 
 interface LinkProperties extends React.HTMLProps<HTMLAnchorElement> {
@@ -44,4 +45,14 @@ export const LinkText = ({
   <span className='a-link_text' {...others}>
     {children}
   </span>
+);
+
+export const ListLink = (properties: LinkProperties): JSXElement => (
+  <ListItem>
+    <Link {...properties} type='list' />
+  </ListItem>
+);
+
+export const DestructiveLink = (properties: LinkProperties): JSXElement => (
+  <Link {...properties} type='destructive' />
 );

--- a/src/components/List/List.stories.tsx
+++ b/src/components/List/List.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { List, ListItem } from '~/src/index';
+import { List, ListItem, ListLink } from '~/src/index';
 
 const meta: Meta<typeof List> = {
   component: List,
@@ -55,15 +55,15 @@ export const Links: Story = {
     isLinks: true,
     children: (
       <>
-        <ListItem>
-          <a href='#'>First Link</a>
-        </ListItem>
-        <ListItem>
-          <a href='#'>Second Link</a>
-        </ListItem>
-        <ListItem>
-          <a href='#'>Third Link</a>
-        </ListItem>
+        <ListLink type='list' href='#'>
+          First Link
+        </ListLink>
+        <ListLink type='list' href='#'>
+          Second Link
+        </ListLink>
+        <ListLink type='list' href='#'>
+          Third Link
+        </ListLink>
       </>
     )
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,12 @@ export { default as Hero } from './components/Hero/Hero';
 export { Icon } from './components/Icon/Icon';
 export { Label } from './components/Label/Label';
 export { default as Layout } from './components/Layout/Layout';
-export { default as Link, LinkText } from './components/Link/Link';
+export {
+  DestructiveLink,
+  default as Link,
+  LinkText,
+  ListLink
+} from './components/Link/Link';
 export { default as List } from './components/List/List';
 export {
   default as ListItem,
@@ -38,3 +43,4 @@ export {
 export { Tagline } from './components/Tagline/Tagline';
 export { TextInput } from './components/TextInput/TextInput';
 export { default as Well } from './components/Well/Well';
+


### PR DESCRIPTION
Closes #134

## Changes
- Avoid underline of icon within a `<Link>` component (https://github.com/cfpb/design-stories/commit/f90d48cda29be0e655aa06cf26c92ec75a3779ba)
  <img width="143" alt="Screenshot 2023-08-15 at 1 09 50 PM" src="https://github.com/cfpb/design-stories/assets/2592907/17b1fc5d-2686-4d79-bc69-1e0a8fd3318e">
- Create new components (`<DestructiveLink>`, `<ListLink>`) to ease creation of these types of Links and update stories to integrate the new components (https://github.com/cfpb/design-stories/commit/ed9380faff595e448c0c27af1746a20b5c5b6a22)
  - DestructiveLink
    <img width="105" alt="Screenshot 2023-08-15 at 1 09 57 PM" src="https://github.com/cfpb/design-stories/assets/2592907/2d40500e-e294-4341-bc0e-a675749dcda4">
  - ListLink
    <img width="103" alt="Screenshot 2023-08-15 at 1 28 44 PM" src="https://github.com/cfpb/design-stories/assets/2592907/b63bdbac-302e-40de-b9c5-aa55fe240ffa">

