### PR TITLE
Field-level notifications

### DIFF
--- a/src/components/Notification/Notification.stories.tsx
+++ b/src/components/Notification/Notification.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { Notification } from '~/src/index';
 
 const meta: Meta<typeof Notification> = {
+  title: 'Components/Notifications',
   component: Notification,
   argTypes: {
     message: { control: 'text' }
@@ -10,9 +11,10 @@ const meta: Meta<typeof Notification> = {
     docs: {
       description: {
         component: `
-### CFPB DS Notification component
+Notifications alert users to the state of a form or page. In forms, notifications can appear at the top of the form or in line with form fields and can highlight successful submissions, errors that need to be corrected, or details to know before submitting the form. When used on a page, notifications can call out important information about the content (including if the content is still loading).
 
-Source: https://cfpb.github.io/design-system/components/notifications
+
+Additional guidance: [Information (base) notification](https://cfpb.github.io/design-system/components/notifications#information-base-notification)&nbsp;&nbsp;[Modifier types](https://cfpb.github.io/design-system/components/notifications#modifier-types)&nbsp;&nbsp;[Behavior](https://cfpb.github.io/design-system/components/notifications#behavior)&nbsp;&nbsp;[Accessibility](https://cfpb.github.io/design-system/components/notifications#accessibility)&nbsp;&nbsp;[Related items](https://cfpb.github.io/design-system/components/notifications#related-items)
 `
       }
     }
@@ -30,6 +32,7 @@ export const Information: Story = {
 
 export const InformationWithExplaination: Story = {
   ...Information,
+  name: 'Information with explaination',
   args: {
     ...Information.args,
     children: 'You can also add an explanation to the notification.'
@@ -38,6 +41,7 @@ export const InformationWithExplaination: Story = {
 
 export const InformationWithLinks: Story = {
   ...Information,
+  name: 'Information with links',
   args: {
     ...Information.args,
     children: 'This is the explanation of the notification.',
@@ -60,9 +64,29 @@ export const Success: Story = {
   args: { ...Information.args, type: 'success', message: '11 results' }
 };
 
+export const SuccessFieldLevel: Story = {
+  ...Information,
+  name: 'Success (field-level)',
+  args: {
+    ...Success.args,
+    isFieldLevel: true,
+    message: 'This is an inline alert with a success state.'
+  }
+};
+
 export const Warning: Story = {
   ...Information,
   args: { ...Information.args, type: 'warning', message: 'No results found.' }
+};
+
+export const WarningFieldLevel: Story = {
+  ...Information,
+  name: 'Warning (field-level)',
+  args: {
+    ...Warning.args,
+    isFieldLevel: true,
+    message: 'This is an inline alert with a warning state.'
+  }
 };
 
 export const Error: Story = {
@@ -70,8 +94,19 @@ export const Error: Story = {
   args: { ...Information.args, type: 'error', message: 'Page not found.' }
 };
 
-export const Loading: Story = {
+export const ErrorFieldLevel: Story = {
   ...Information,
+  name: 'Error (field-level)',
+  args: {
+    ...Error.args,
+    isFieldLevel: true,
+    message: 'This is an inline alert with an error state.'
+  }
+};
+
+export const InProgress: Story = {
+  ...Information,
+  name: 'In-progress',
   args: {
     ...Information.args,
     type: 'loading',

--- a/src/components/Notification/Notification.test.tsx
+++ b/src/components/Notification/Notification.test.tsx
@@ -65,4 +65,41 @@ describe('<Notification />', () => {
     expect(externalIcon).toBeInTheDocument();
     expect(externalIcon).toHaveClass('cf-icon-svg__external-link');
   });
+
+  it('renders field-level notifications', async () => {
+    const testId = 'field-level-warning';
+    render(
+      <Notification
+        data-testid={testId}
+        type='warning'
+        isFieldLevel
+        message='squish'
+      />
+    );
+    const element = screen.getByTestId(testId);
+
+    // Renders Icon
+    const icon = await within(element).findByRole('img');
+    expect(icon).toBeInTheDocument();
+
+    // Render message
+    const message = screen.queryByTestId('message');
+    expect(message).toBeInTheDocument();
+  });
+
+  it('provides feedback for unsupported field-level notification type', async () => {
+    const testId = 'field-level-warning';
+    render(
+      <Notification
+        data-testid={testId}
+        type='info'
+        isFieldLevel
+        message='squish'
+      />
+    );
+    // Renders error message
+    const message =
+      '[Error] Unsupported field-level notification type provided: info';
+    expect(await screen.findByText(message)).toBeVisible();
+  });
 });

--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -2,6 +2,8 @@ import classNames from 'classnames';
 import type { HeadingLevel } from '../../types/headingLevel';
 import { Icon } from '../Icon/Icon';
 import './Notification.css';
+import type { NotificationFieldLevelType } from './NotificationFieldLevel';
+import { NotificationFieldLevel } from './NotificationFieldLevel';
 import type { NotificationLinkProperties } from './NotificationLink';
 import { NotificationLink } from './NotificationLink';
 
@@ -21,13 +23,13 @@ export type NotificationType =
   | 'warning';
 
 interface NotificationProperties {
-  type?: string;
-  // type?: NotificationType;
+  type?: NotificationFieldLevelType | NotificationType;
   message?: React.ReactNode;
   headingLevel?: HeadingLevel;
   children?: React.ReactNode;
   links?: NotificationLinkProperties[];
   isVisible?: boolean;
+  isFieldLevel?: boolean;
   showIcon?: boolean;
 }
 
@@ -43,6 +45,7 @@ interface NotificationProperties {
  * @param message Notification reason
  * @param type Type of notification
  * @param isVisible Display/hide notification
+ * @param isFieldLevel Render a field-level notification
  * @param showIcon Display/hide notification icon
  * @returns ReactElement
  */
@@ -54,11 +57,21 @@ export const Notification = ({
   message,
   type = 'info',
   isVisible = true,
+  isFieldLevel = false,
   showIcon = true,
   ...properties
 }: NotificationProperties &
   React.HTMLAttributes<HTMLDivElement>): React.ReactElement | null => {
   if (!isVisible) return null;
+
+  if (isFieldLevel) {
+    return (
+      // @ts-expect-error NotificationFieldLevel provides feedback for incompatible `type` values
+      <NotificationFieldLevel
+        {...{ type, message, isVisible, ...properties }}
+      />
+    );
+  }
 
   const classes = classNames(
     'm-notification',

--- a/src/components/Notification/NotificationFieldLevel.tsx
+++ b/src/components/Notification/NotificationFieldLevel.tsx
@@ -34,7 +34,9 @@ export const NotificationFieldLevel = ({
 
   if (!['error', 'success', 'warning'].includes(type))
     return (
-      <>[Error] Unsupported field-level notification type provided: {type}</>
+      <p data-testid='message'>
+        [Error] Unsupported field-level notification type provided: {type}
+      </p>
     );
 
   return (
@@ -44,7 +46,9 @@ export const NotificationFieldLevel = ({
       {...properties}
     >
       <Icon name={MapTypeToIconName[type]} alt={type} withBg />
-      <span className='a-form-alert_text'>{message}</span>
+      <span className='a-form-alert_text' data-testid='message'>
+        {message}
+      </span>
     </div>
   );
 };

--- a/src/components/Notification/NotificationFieldLevel.tsx
+++ b/src/components/Notification/NotificationFieldLevel.tsx
@@ -1,0 +1,50 @@
+import type { JSXElement } from '~/src/types/jsxElement';
+import { Icon } from '../Icon/Icon';
+
+export type NotificationFieldLevelType = '' | 'error' | 'success' | 'warning';
+
+export enum NotificationFieldLevelClass {
+  '' = '',
+  'error' = '__error',
+  'success' = '__success',
+  'warning' = '__warning'
+}
+
+export const MapTypeToIconName = {
+  '': '',
+  error: 'error',
+  success: 'approved',
+  warning: 'warning'
+};
+
+interface NotificationFieldLevelProperties
+  extends React.HTMLAttributes<HTMLDivElement> {
+  type: NotificationFieldLevelType;
+  message: React.ReactNode;
+  isVisible: boolean;
+}
+
+export const NotificationFieldLevel = ({
+  type,
+  message,
+  isVisible,
+  ...properties
+}: NotificationFieldLevelProperties): JSXElement => {
+  if (!isVisible) return null;
+
+  if (!['error', 'success', 'warning'].includes(type))
+    return (
+      <>[Error] Unsupported field-level notification type provided: {type}</>
+    );
+
+  return (
+    <div
+      className={`a-form-alert a-form-alert${NotificationFieldLevelClass[type]}`}
+      role='alert'
+      {...properties}
+    >
+      <Icon name={MapTypeToIconName[type]} alt={type} withBg />
+      <span className='a-form-alert_text'>{message}</span>
+    </div>
+  );
+};

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -1,4 +1,6 @@
-import { Icon } from '../Icon/Icon';
+import { Notification } from '../Notification/Notification';
+import type { NotificationFieldLevelType } from '../Notification/NotificationFieldLevel';
+import { NotificationFieldLevelClass } from '../Notification/NotificationFieldLevel';
 
 type TextInputReference =
   | React.RefObject<HTMLInputElement>
@@ -27,26 +29,11 @@ interface CustomTextInputProperties {
   inputProps?: JSX.IntrinsicElements['input'];
   inputRef?: TextInputReference;
   isDisabled?: boolean;
-  notificationType?: NotificationType;
+  notificationType?: NotificationFieldLevelType;
   textNotification?: string;
   type?: InputType;
   width?: 'default' | 'full';
 }
-
-type NotificationType = '' | 'error' | 'success' | 'warning';
-
-enum NotificationClass {
-  'success' = '__success',
-  'warning' = '__warning',
-  'error' = '__error',
-  '' = ''
-}
-
-const iconType = {
-  success: 'approved',
-  warning: 'warning',
-  error: 'error'
-};
 
 export type OptionalTextInputProperties = CustomTextInputProperties &
   JSX.IntrinsicElements['input'];
@@ -77,13 +64,13 @@ export function TextInput({
   const styles = [...baseStyles, ...widthStyles[width]];
   const classes = [
     className,
-    `a-text-input${NotificationClass[notificationType]}`,
+    `a-text-input${NotificationFieldLevelClass[notificationType]}`,
     ...styles
   ].join(' ');
 
   return (
     <div
-      className={`m-form-field m-form-field${NotificationClass[notificationType]}`}
+      className={`m-form-field m-form-field${NotificationFieldLevelClass[notificationType]}`}
     >
       <input
         data-testid='textInput'
@@ -96,21 +83,12 @@ export function TextInput({
         ref={inputRef}
         {...inputProperties}
       />
-
-      {notificationType ? (
-        <div
-          className={`a-form-alert a-form-alert${NotificationClass[notificationType]}`}
-          id={id}
-          role='alert'
-        >
-          <Icon
-            name={iconType[notificationType]}
-            alt={notificationType}
-            withBg
-          />
-          <span className='a-form-alert_text'>{textNotification}</span>
-        </div>
-      ) : null}
+      <Notification
+        id={`${id}-notification`}
+        type={notificationType}
+        message={textNotification}
+        isFieldLevel
+      />
     </div>
   );
 }


### PR DESCRIPTION
Closes #164 

Create the ability to render field-level notifications independently of the TextInput component, so that these notifications can be applied to other types of user input.

## Changes

- Create a separate NotificationFieldLevel component, which implements a subset of the states from Notification for use at the field-level
- Integrate NotificationFieldLevel into Notification component for ease of use
- Align Notification component docs with Design System
- Integrate updated field-level notification into TextInput component
- Add tests


## How to test this PR

1. yarn vitest Notification
2. yarn vitest TextInput

## Screenshots

![screencapture-localhost-6006-2023-09-13-17_31_37](https://github.com/cfpb/design-system-react/assets/2592907/2af5e8c5-e55d-4ad0-9c07-dec0e853967a)

