### PR TITLE
fix: Hide notification if there is no text content

### DIFF
--- a/src/components/Notification/NotificationFieldLevel.tsx
+++ b/src/components/Notification/NotificationFieldLevel.tsx
@@ -11,7 +11,7 @@ export enum NotificationFieldLevelClass {
 }
 
 export const MapTypeToIconName = {
-  '': '',
+  '': 'information',
   error: 'error',
   success: 'approved',
   warning: 'warning'
@@ -19,20 +19,20 @@ export const MapTypeToIconName = {
 
 interface NotificationFieldLevelProperties
   extends React.HTMLAttributes<HTMLDivElement> {
-  type: NotificationFieldLevelType;
+  type?: NotificationFieldLevelType;
   message: React.ReactNode;
   isVisible: boolean;
 }
 
 export const NotificationFieldLevel = ({
-  type,
+  type = '',
   message,
   isVisible,
   ...properties
 }: NotificationFieldLevelProperties): JSXElement => {
-  if (!isVisible) return null;
+  if (!isVisible || !message) return null;
 
-  if (!['error', 'success', 'warning'].includes(type))
+  if (!['error', 'success', 'warning', ''].includes(type))
     return (
       <p data-testid='message'>
         [Error] Unsupported field-level notification type provided: {type}


### PR DESCRIPTION
Closes #178 

The default TextInput story was showing an error, this addresses that situation. 

## Screenshots
|Before|After|
|---|---|
|![Before](https://github.com/cfpb/design-system-react/assets/2592907/7f3ac783-64ed-4d51-b635-d667a681b857)|![After](https://github.com/cfpb/design-system-react/assets/2592907/c0eee35c-1964-40be-9142-975274dacb6b)|
