### PR TITLE
fix: [Checkboxes] Standardize example helper text

### DIFF
--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -40,7 +40,7 @@ export const StandardCheckboxWithHelperText: Story = {
     id: 'StandardCheckboxWithHelper',
     name: 'StandardCheckboxWithHelper',
     label: 'Standard checkbox with helper text',
-    helperText: 'This is optional helper text for the standard checkbox'
+    helperText: 'This is optional helper text'
   }
 };
 
@@ -65,7 +65,6 @@ export const LargeTargetAreaCheckboxWithHelperText: Story = {
     name: 'LargeCheckboxWithHelperText',
     label: 'Large target area checkbox helper text',
     isLarge: true,
-    helperText:
-      'This is optional helper text for the large target area checkbox'
+    helperText: 'This is optional helper text'
   }
 };


### PR DESCRIPTION
Part of #168 

## Changes

- Make helper text examples say: `(This is optional helper text)`

![Screenshot 2023-09-30 at 10 30 56 AM](https://github.com/cfpb/design-system-react/assets/2592907/947dda00-89bc-49e3-9bbf-7ac9f17bdd24)

