### PR TITLE
[Component] Radio buttons

### DIFF
--- a/src/components/Checkbox/Checkbox.test.tsx
+++ b/src/components/Checkbox/Checkbox.test.tsx
@@ -48,6 +48,7 @@ describe('Checkbox', () => {
 
   it('Renders helper text that toggles checkbox when clicked', async () => {
     const helperText = 'This is optional helper text for the checkbox';
+    const helperTextOuput = `(${helperText})`;
 
     render(<CheckboxTestWrapper {...defaultProps} helperText={helperText} />);
 
@@ -55,7 +56,7 @@ describe('Checkbox', () => {
     expect(checkbox.getAttribute(attributeAria)).toMatch('false');
 
     // Clicking helper text correctly updates checkbox
-    const helper = await screen.findByText(helperText);
+    const helper = await screen.findByText(helperTextOuput);
     act(() => helper.click());
     expect(checkbox.getAttribute(attributeAria)).toMatch('true');
   });

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -6,6 +6,7 @@ import type {
   RefObject
 } from 'react';
 import { useCallback } from 'react';
+import { HelperText } from '../HelperText/HelperText';
 
 export interface CheckboxProperties {
   /** Unique identifier for this checkbox */
@@ -87,9 +88,7 @@ export const Checkbox = ({
       />
       <label id={`${id}-label`} className='a-label' htmlFor={id}>
         {label}
-        {helperText ? (
-          <small className='a-label_helper'>({helperText})</small>
-        ) : undefined}
+        <HelperText>{helperText}</HelperText>
       </label>
     </div>
   );

--- a/src/components/HelperText/HelperText.tsx
+++ b/src/components/HelperText/HelperText.tsx
@@ -1,0 +1,22 @@
+import classNames from 'classnames';
+import type React from 'react';
+
+type HelperTextProperties = React.HTMLProps<HTMLDivElement>;
+
+/**
+ * A utility component to consistently display helper text for input elements
+ */
+export const HelperText = ({
+  children,
+  className,
+  ...properties
+}: HelperTextProperties): JSX.Element | null => {
+  if (!children) return null;
+  const cnames = ['a-label_helper', className];
+
+  return (
+    <small className={classNames(cnames)} {...properties}>
+      ({children})
+    </small>
+  );
+};

--- a/src/components/Radio/Radio.stories.tsx
+++ b/src/components/Radio/Radio.stories.tsx
@@ -1,22 +1,16 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { Radio } from '~/src/index';
 
+/**
+ * Use radio buttons when the user can choose only one option out of a list. Use these for a small number of discrete elements—avoid long lists of radio buttons (usually no more than 6-8 options). When there are more than two options, stack radio buttons vertically.
+ * 
+ * Source: https://cfpb.github.io/design-system/components/radio-buttons
+ */
 const meta: Meta<typeof Radio> = {
   component: Radio,
   argTypes: {
     isDisabled: { control: 'boolean' },
     isLarge: { control: 'boolean' }
-  },
-  parameters: {
-    docs: {
-      description: {
-        component: `
-### CFPB DS - Radio component
-
-Source: https://cfpb.github.io/design-system/components/expandables
-`
-      }
-    }
   }
 };
 
@@ -24,31 +18,42 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const DefaultRadio: Story = {
-  args: { id: 'testRadio', label: 'Default Radio', name: 'Radio select' }
+const helperText = 'This is optional helper text';
+
+export const StandardRadio: Story = {
+  name: 'Standard radio button',
+  args: {
+    id: 'testRadio',
+    label: 'Standard radio button',
+    name: 'Radio select'
+  }
 };
 
-export const RadioWithHelper: Story = {
+export const StandardRadioWithHelper: Story = {
+  name: 'Standard radio button with helper text',
   args: {
-    ...DefaultRadio.args,
-    id: 'RadioWithHelper',
-    helperText: 'This is optional helper text for the radio'
+    ...StandardRadio.args,
+    id: 'StandardRadioWithHelper',
+    helperText
   }
 };
 
 export const LargeRadio: Story = {
+  name: 'Large target area radio button',
   args: {
-    ...DefaultRadio.args,
+    ...StandardRadio.args,
     id: 'LargeRadio',
-    isLarge: true
+    isLarge: true,
+    label: 'Large target area radio button'
   }
 };
 
 export const LargeRadioWithHelper: Story = {
+  name: 'Large target area radio button with helper text',
   args: {
-    ...DefaultRadio.args,
+    ...LargeRadio.args,
     id: 'LargeRadioWithHelper',
     isLarge: true,
-    helperText: 'This is optional helper text for the large radio'
+    helperText
   }
 };

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -1,4 +1,5 @@
 import type React from 'react';
+import { HelperText } from '../HelperText/HelperText';
 
 interface RadioProperties {
   id: string;
@@ -46,9 +47,7 @@ export const Radio = ({
       />
       <label className='a-label' htmlFor={id}>
         {label}
-        {helperText ? (
-          <small className='a-label_helper'>{helperText}</small>
-        ) : undefined}
+        <HelperText>{helperText}</HelperText>
       </label>
     </div>
   );

--- a/src/components/RadioButton/RadioButton.stories.tsx
+++ b/src/components/RadioButton/RadioButton.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { RadioButton } from '~/src/index';
 
 /**
- * Use radio buttons when the user can choose only one option out of a list. Use these for a small number of discrete elements—avoid long lists of radio buttons (usually no more than 6-8 options). When there are more than two options, stack radio buttons vertically.
+ * Use radio buttons when the user can select exactly one option from a group. Avoid long lists of radio buttons (usually no more than 6-8 options). When there are more than two options, stack radio buttons vertically. Use [checkboxes](https://cfpb.github.io/design-system/components/checkboxes) when the user can select more than one option from a group.
  *
  * Source: https://cfpb.github.io/design-system/components/radio-buttons
  */

--- a/src/components/RadioButton/RadioButton.stories.tsx
+++ b/src/components/RadioButton/RadioButton.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof RadioButton> = {
   component: RadioButton,
   title: 'Components/Radio buttons',
   argTypes: {
-    isDisabled: { control: 'boolean' },
+    disabled: { control: 'boolean' },
     isLarge: { control: 'boolean' }
   }
 };

--- a/src/components/RadioButton/RadioButton.stories.tsx
+++ b/src/components/RadioButton/RadioButton.stories.tsx
@@ -1,13 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Radio } from '~/src/index';
+import { RadioButton } from '~/src/index';
 
 /**
  * Use radio buttons when the user can choose only one option out of a list. Use these for a small number of discrete elements—avoid long lists of radio buttons (usually no more than 6-8 options). When there are more than two options, stack radio buttons vertically.
- * 
+ *
  * Source: https://cfpb.github.io/design-system/components/radio-buttons
  */
-const meta: Meta<typeof Radio> = {
-  component: Radio,
+const meta: Meta<typeof RadioButton> = {
+  component: RadioButton,
+  title: 'Components/Radio buttons',
   argTypes: {
     isDisabled: { control: 'boolean' },
     isLarge: { control: 'boolean' }

--- a/src/components/RadioButton/RadioButton.test.tsx
+++ b/src/components/RadioButton/RadioButton.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Radio } from './Radio';
+import { RadioButton } from './RadioButton';
 
 const buildProperties = (
   additive: number | string
@@ -10,27 +10,29 @@ const buildProperties = (
   label: `label-${additive}`
 });
 
-describe('<Radio />', () => {
+describe('<RadioButton />', () => {
   const helperText = 'helperText goes here';
+  const helperTextOutput = '(helperText goes here)';
+
   const role = 'radio';
 
   it('renders labels correctly', () => {
     const properties = buildProperties('first');
-    render(<Radio {...properties} />);
+    render(<RadioButton {...properties} />);
     expect(screen.getByText(properties.label)).toBeInTheDocument();
   });
 
   it('renders helperText', () => {
     const properties = buildProperties('helper');
-    render(<Radio {...properties} helperText={helperText} />);
-    expect(screen.getByText(helperText)).toBeInTheDocument();
+    render(<RadioButton {...properties} helperText={helperText} />);
+    expect(screen.getByText(helperTextOutput)).toBeInTheDocument();
   });
 
   it('isLarge', () => {
     const properties = buildProperties('large');
-    render(<Radio {...properties} helperText={helperText} isLarge />);
+    render(<RadioButton {...properties} helperText={helperText} isLarge />);
 
-    expect(screen.getByText(helperText)).toBeInTheDocument();
+    expect(screen.getByText(helperTextOutput)).toBeInTheDocument();
     expect(screen.getByTestId('radio-container').getAttribute('class')).toMatch(
       'm-form-field__lg-target'
     );
@@ -38,7 +40,7 @@ describe('<Radio />', () => {
 
   it('isDisabled', () => {
     const properties = buildProperties('disabled');
-    render(<Radio {...properties} isDisabled />);
+    render(<RadioButton {...properties} isDisabled />);
 
     const element = screen.getByRole(role);
 
@@ -49,7 +51,7 @@ describe('<Radio />', () => {
 
   it('Select via click', () => {
     const properties = buildProperties('click');
-    render(<Radio {...properties} />);
+    render(<RadioButton {...properties} />);
 
     const element = screen.getByRole(role);
     expect(element).not.toBeChecked();
@@ -62,7 +64,7 @@ describe('<Radio />', () => {
   it('Select via keyboard', async () => {
     const user = userEvent.setup();
     const properties = buildProperties('keyboard');
-    render(<Radio {...properties} />);
+    render(<RadioButton {...properties} />);
 
     const element = screen.getByRole(role);
     expect(element).not.toBeChecked();

--- a/src/components/RadioButton/RadioButton.test.tsx
+++ b/src/components/RadioButton/RadioButton.test.tsx
@@ -40,7 +40,7 @@ describe('<RadioButton />', () => {
 
   it('isDisabled', () => {
     const properties = buildProperties('disabled');
-    render(<RadioButton {...properties} isDisabled />);
+    render(<RadioButton {...properties} disabled />);
 
     const element = screen.getByRole(role);
 

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -12,7 +12,7 @@ interface RadioProperties {
     | ((instance: HTMLInputElement | null) => void)
     | null
     | undefined;
-  isDisabled?: boolean;
+  disabled?: boolean;
   isLarge?: boolean;
   name?: string;
 }
@@ -24,7 +24,7 @@ export const RadioButton = ({
   name,
   helperText,
   className,
-  isDisabled = false,
+  disabled = false,
   isLarge = false,
   label,
   inputRef
@@ -43,7 +43,7 @@ export const RadioButton = ({
         name={name ?? id}
         className={classes}
         ref={inputRef}
-        disabled={isDisabled}
+        disabled={disabled}
       />
       <label className='a-label' htmlFor={id}>
         {label}

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -19,7 +19,7 @@ interface RadioProperties {
 const baseStyles = ['a-radio'];
 const containerBaseStyles = ['m-form-field m-form-field__radio'];
 
-export const Radio = ({
+export const RadioButton = ({
   id,
   name,
   helperText,
@@ -53,4 +53,4 @@ export const Radio = ({
   );
 };
 
-export default Radio;
+export default RadioButton;

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ export { default as Navbar } from './components/Navbar/Navbar';
 export { Notification } from './components/Notification/Notification';
 export { default as PageHeader } from './components/PageHeader/PageHeader';
 export { Pagination } from './components/Pagination/Pagination';
-export { Radio } from './components/Radio/Radio';
+export { RadioButton } from './components/RadioButton/RadioButton';
 export {
   TableComplex,
   TableFilter,


### PR DESCRIPTION
Closes #187 

## Changes

- Updates Storybook text to match Checkbox format
- Adds intro paragraph and corrects `Source` link
- Renames component from `Radio` to `RadioButton` for clarity
- Renames the `isDisabled` prop to match the HTML standard `disabled` instead
- Creates a HelperText component to easily and consistently apply the appropriate styles
- Scope creep: Integrates HelperText into the Checkbox component

## How to test this PR

1. yarn vitest Radio

## Screenshots

### Sidebar

![Screenshot 2023-10-02 at 11 44 14 AM](https://github.com/cfpb/design-system-react/assets/2592907/d374a87f-bf16-4ef6-875b-c55b14ca4552)

### Overview
![Screenshot 2023-10-02 at 2 18 24 PM](https://github.com/cfpb/design-system-react/assets/2592907/9b24afa5-4dde-428b-862d-a642daae82d0)

