### PR TITLE
fix: [Eyebrow] display as <div> with ".h5" class instead of <h5>

### DIFF
--- a/src/components/Headings/Heading.test.tsx
+++ b/src/components/Headings/Heading.test.tsx
@@ -56,8 +56,9 @@ describe('<Heading />', () => {
     const current = screen.getByTestId(testid);
 
     expect(current).toBeInTheDocument();
-    expect(current.tagName.toLowerCase()).toBe('h5');
+    expect(current.tagName.toLowerCase()).toBe('div');
     expect(current.className.includes('eyebrow')).toBeTruthy();
+    expect(current.className.includes('h5')).toBeTruthy();
   });
 
   it('Renders Slug heading', () => {

--- a/src/components/Headings/Heading.tsx
+++ b/src/components/Headings/Heading.tsx
@@ -39,8 +39,8 @@ export const Heading = ({
     DynamicHeading = 'h1';
     classes.push('superheading');
   } else if (type === 'eyebrow') {
-    DynamicHeading = 'h5';
-    classes.push('eyebrow');
+    DynamicHeading = 'div';
+    classes.push('h5 eyebrow');
   } else DynamicHeading = `h${type}`;
 
   return (

--- a/src/components/Headings/Headings.stories.tsx
+++ b/src/components/Headings/Headings.stories.tsx
@@ -72,7 +72,7 @@ export const Eyebrow: Story = {
   render: arguments_ => (
     <>
       <Heading {...arguments_} />
-      <Heading>Heading 1</Heading>
+      <div className='h1'>Heading 1</div>
     </>
   )
 };


### PR DESCRIPTION
Closes #203 

## Changes
No visual change, just a structural change in how the heading is implemented to improve accessibility (no longer displaying an h5 ahead of an h1)

## Screenshots
|Before|After|
|---|---|
|<img width="207" alt="eyebrow-before" src="https://github.com/cfpb/design-system-react/assets/2592907/bb0e6020-2207-4394-af45-5a9f6c7399ce">|<img width="195" alt="eyebrow-after" src="https://github.com/cfpb/design-system-react/assets/2592907/da263166-f9c1-4996-9dae-ad6bfd231981">|

