### PR TITLE
docs(tagline): modify docs to verify component

### DIFF
--- a/src/components/Tagline/Tagline.stories.tsx
+++ b/src/components/Tagline/Tagline.stories.tsx
@@ -8,7 +8,8 @@ const meta: Meta<typeof Tagline> = {
     docs: {
       description: {
         component: `
-### CFPB DS - Tagline component
+
+Taglines are short paragraphs of text with a USA flag to their left.
 
 Source: https://cfpb.github.io/design-system/patterns/taglines
 `
@@ -31,8 +32,10 @@ export const StandardTagline: Story = {
     </Tagline>
   )
 };
+StandardTagline.storyName = 'Standard tagline';
 
 export const LargeTagline: Story = {
   ...StandardTagline,
   args: { isLarge: true }
 };
+LargeTagline.storyName = 'Large tagline';


### PR DESCRIPTION
I went through and [verified the Tagline component](https://github.com/cfpb/design-system-react/issues/205) as part of the work on the banner component. Only small changes to the documentation appear to be needed. I didn't add the deprecated "Extra large tagline" story from the design system, since it was deprecated and all, but we can chat about that at the DSR sync. 

## Changes

- add component description
- remove heading
- change stories to sentence case

## How to test this PR

1. Take a peek at the DSR and see how it looks

## Screenshots
![Screenshot 2023-10-19 at 9 48 05 AM](https://github.com/cfpb/design-system-react/assets/19983248/684c015c-bd8d-4a6c-b054-0fdb1158c7e0)

## Notes
I didn't mark this component as "verified" in this PR, since I'm not sure if we have an official stamp of approval process yet, so I'll hold off till at least we chat about it at the sync.
