### PR TITLE
fix: [Storybook] Improve readability of code blocks

### DIFF
--- a/src/assets/styles/_shared.less
+++ b/src/assets/styles/_shared.less
@@ -29,7 +29,8 @@
 
   /** Applying DS font sizing **/
   .sbdocs > p, // Custom overview page headings
-  .sbdocs .sbdocs-title + div p // Auto-generated page headings
+  .sbdocs .sbdocs-title + div p, // Auto-generated page headings
+  pre.prismjs // Code blocks
   {
     font-size: 16px;
   }
@@ -38,4 +39,21 @@
   * {
     font-family: 'Avenir Next', Arial, sans-serif;
   }
+
+  /* 
+  Make code block plain-text readable (workaround since we can't change code highlighting theme) 
+  https://github.com/storybookjs/storybook/issues/9641
+  */
+  pre.prismjs {
+    color: white;
+  }
+}
+
+/* 
+Apply a global line-height that doesn't interfere with component Stories 
+that have their own line-height settings. 
+*/
+pre.prismjs,
+:where(p:not(.sb-story *, #storybook-root *)) {
+  line-height: 22px !important;
 }


### PR DESCRIPTION
Closes #214 

## Changes

- Make code blocks' font white
- Increase code blocks' font size
- Increase code blocks' line height

## How to test this PR

1. Visit [deployed preview](https://deploy-preview-220--cfpb-design-system-react.netlify.app/?path=/docs/components-draft-taglines--overview)
1. Click `Show Code` for a Story
2. Observe

## Screenshots
![Screenshot 2023-10-26 at 3 34 41 PM](https://github.com/cfpb/design-system-react/assets/2592907/323fe5e1-7473-4546-a9af-192bf2c7db1f)

## Notes

- There's a [two year old issue in Storybook](https://github.com/storybookjs/storybook/issues/9641) to enable users to change the theme used for syntax highlighting but it doesn't have much traction, so this is our workaround. 
