### PR TITLE
Add Bill as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @meissadia @shindigira
+* @meissadia @shindigira @billhimmelsbach


### PR DESCRIPTION
Closes #226 

PRs approved by Bill are blocked until he gets added as a CODEOWNER. 
 
We'll probably have to disable that rule, merge this PR, then re-enable it. 

