### PR TITLE
fix(chromatic): generate webpack-stats.json with vite

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,3 +1,5 @@
+import turbosnap from 'vite-plugin-turbosnap';
+
 module.exports = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
   staticDirs: ['../src/assets/'],
@@ -25,6 +27,13 @@ module.exports = {
     // Skip type declaration generation for non-dist builds
     config.plugins = config.plugins.filter(
       plugin => plugin.name !== 'vite:dts'
+    );
+
+    config.plugins = config.plugins.concat(
+      turbosnap({
+        // This should be the base path of your storybook.  In monorepos, you may only need process.cwd().
+        rootDir: config.root ?? process.cwd()
+      })
     );
 
     // return the customized config

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -29,9 +29,9 @@ module.exports = {
       plugin => plugin.name !== 'vite:dts'
     );
 
+    // load Chromatic's recommended vite plugin for dist builds to create preview-stats.json
     config.plugins = config.plugins.concat(
       turbosnap({
-        // This should be the base path of your storybook.  In monorepos, you may only need process.cwd().
         rootDir: config.root ?? process.cwd()
       })
     );

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "vite-plugin-dts": "^2.2.0",
     "vite-plugin-pwa": "^0.14.7",
     "vite-plugin-react-remove-attributes": "^1.0.3",
+    "vite-plugin-turbosnap": "^1.0.3",
     "vite-svg-loader": "^4.0.0",
     "vite-tsconfig-paths": "3.5.2",
     "vitest": "0.25.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "start": "yarn storybook",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build -o dist-storybook --webpack-stats-json",
-    "chromatic": "chromatic --debug --storybook-build-dir dist-storybook --only-changed"
+    "chromatic": "chromatic --storybook-build-dir dist-storybook --only-changed"
   },
   "dependencies": {
     "@cfpb/cfpb-design-system": "^0.32.0",
@@ -115,6 +115,7 @@
     "npm-run-all": "4.1.5",
     "postcss": "8.4.19",
     "prettier": "2.7.1",
+    "rollup-plugin-webpack-stats": "^0.2.1",
     "start-server-and-test": "1.14.0",
     "storybook": "^7.0.6",
     "storybook-dark-mode": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "start": "yarn storybook",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build -o dist-storybook --webpack-stats-json",
-    "chromatic": "chromatic --storybook-build-dir dist-storybook --only-changed"
+    "chromatic": "chromatic --only-changed"
   },
   "dependencies": {
     "@cfpb/cfpb-design-system": "^0.32.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "validate": "run-p lint test:ci test:e2e:headless",
     "start": "yarn storybook",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build -o dist-storybook --webpack-stats-json",
+    "build-storybook": "storybook build -o dist-storybook",
     "chromatic": "chromatic --storybook-build-dir dist-storybook --only-changed"
   },
   "dependencies": {
@@ -115,10 +115,8 @@
     "npm-run-all": "4.1.5",
     "postcss": "8.4.19",
     "prettier": "2.7.1",
-    "rollup-plugin-webpack-stats": "^0.2.1",
     "start-server-and-test": "1.14.0",
     "storybook": "^7.0.6",
-    "storybook-dark-mode": "^3.0.1",
     "stylelint": "14.15.0",
     "stylelint-config-prettier": "9.0.4",
     "stylelint-config-standard": "29.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "start": "yarn storybook",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build -o dist-storybook --webpack-stats-json",
-    "chromatic": "chromatic --only-changed"
+    "chromatic": "chromatic --debug --storybook-build-dir dist-storybook --only-changed"
   },
   "dependencies": {
     "@cfpb/cfpb-design-system": "^0.32.0",
@@ -117,6 +117,7 @@
     "prettier": "2.7.1",
     "start-server-and-test": "1.14.0",
     "storybook": "^7.0.6",
+    "storybook-dark-mode": "^3.0.1",
     "stylelint": "14.15.0",
     "stylelint-config-prettier": "9.0.4",
     "stylelint-config-standard": "29.0.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,6 @@
 import eslintPlugin from '@nabla/vite-plugin-eslint';
 import react from '@vitejs/plugin-react';
 import { resolve } from 'node:path';
-import { webpackStats } from 'rollup-plugin-webpack-stats';
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 import VitePluginReactRemoveAttributes from 'vite-plugin-react-remove-attributes';
@@ -27,8 +26,7 @@ export default defineConfig(() => ({
     }),
     VitePluginReactRemoveAttributes({
       attributes: ['data-testid']
-    }),
-    webpackStats({ fileName: 'preview-stats.json' })
+    })
   ],
   test: {
     globals: true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,7 +28,7 @@ export default defineConfig(() => ({
     VitePluginReactRemoveAttributes({
       attributes: ['data-testid']
     }),
-    webpackStats()
+    webpackStats({ fileName: 'preview-stats.json' })
   ],
   test: {
     globals: true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import eslintPlugin from '@nabla/vite-plugin-eslint';
 import react from '@vitejs/plugin-react';
 import { resolve } from 'node:path';
+import { webpackStats } from 'rollup-plugin-webpack-stats';
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 import VitePluginReactRemoveAttributes from 'vite-plugin-react-remove-attributes';
@@ -26,7 +27,8 @@ export default defineConfig(() => ({
     }),
     VitePluginReactRemoveAttributes({
       attributes: ['data-testid']
-    })
+    }),
+    webpackStats()
   ],
   test: {
     globals: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3721,38 +3721,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/addons@npm:^7.0.0":
-  version: 7.5.2
-  resolution: "@storybook/addons@npm:7.5.2"
-  dependencies:
-    "@storybook/manager-api": 7.5.2
-    "@storybook/preview-api": 7.5.2
-    "@storybook/types": 7.5.2
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 9304422cbc64137e754b345d9c2f329a2b620a21a6756816268643a33259413f44122cd603159e95281c2aed316e3040d10795fdbfc726f7db99de3c0c7c5ec0
-  languageName: node
-  linkType: hard
-
-"@storybook/api@npm:^7.0.0":
-  version: 7.5.2
-  resolution: "@storybook/api@npm:7.5.2"
-  dependencies:
-    "@storybook/client-logger": 7.5.2
-    "@storybook/manager-api": 7.5.2
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-  peerDependenciesMeta:
-    react:
-      optional: true
-    react-dom:
-      optional: true
-  checksum: d14b1ac8465018054ed74aae3bbde2f3f602f9d824f665d4dad0835cbca64606ea491ae98709ff0191cb84eabb3a63660ab76ef15ab5f2ac53031923896b361e
-  languageName: node
-  linkType: hard
-
 "@storybook/blocks@npm:7.4.3":
   version: 7.4.3
   resolution: "@storybook/blocks@npm:7.4.3"
@@ -3892,20 +3860,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/channels@npm:7.5.2":
-  version: 7.5.2
-  resolution: "@storybook/channels@npm:7.5.2"
-  dependencies:
-    "@storybook/client-logger": 7.5.2
-    "@storybook/core-events": 7.5.2
-    "@storybook/global": ^5.0.0
-    qs: ^6.10.0
-    telejson: ^7.2.0
-    tiny-invariant: ^1.3.1
-  checksum: 60dcd85317628af1dfb5c4c75a35bd317db3165cfe5c52ec16fd03628aadff693a2b5fd936d6692c5b2a7aa6929db84ac2ec3ea9de563243a5f049f0faadb23a
-  languageName: node
-  linkType: hard
-
 "@storybook/cli@npm:7.4.3":
   version: 7.4.3
   resolution: "@storybook/cli@npm:7.4.3"
@@ -3995,15 +3949,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/client-logger@npm:7.5.2":
-  version: 7.5.2
-  resolution: "@storybook/client-logger@npm:7.5.2"
-  dependencies:
-    "@storybook/global": ^5.0.0
-  checksum: d39b2fce23c3f1acd9b66241c65ccfe910dd6dc0c09d666763f6d3f9277eb04d9076e00a7528d5ff444a2c6f1d464f227f259efd20523eb6fec3eb66ff37ff86
-  languageName: node
-  linkType: hard
-
 "@storybook/codemod@npm:7.4.3":
   version: 7.4.3
   resolution: "@storybook/codemod@npm:7.4.3"
@@ -4044,27 +3989,6 @@ __metadata:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
   checksum: e286bd716535fcbfb722d9da122c2563432a2ffb8131a7b0e8be576465aa424f5aa3b9245311edd8f58a3b04aff5d99e2ac30f7d684d88c4c532bd75e8757c3b
-  languageName: node
-  linkType: hard
-
-"@storybook/components@npm:^7.0.0":
-  version: 7.5.2
-  resolution: "@storybook/components@npm:7.5.2"
-  dependencies:
-    "@radix-ui/react-select": ^1.2.2
-    "@radix-ui/react-toolbar": ^1.0.4
-    "@storybook/client-logger": 7.5.2
-    "@storybook/csf": ^0.1.0
-    "@storybook/global": ^5.0.0
-    "@storybook/theming": 7.5.2
-    "@storybook/types": 7.5.2
-    memoizerific: ^1.11.3
-    use-resize-observer: ^9.1.0
-    util-deprecate: ^1.0.2
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: ec1f9beab12e61b4a9e8f7f574cfc1ba8219d1050e499eaed262f0243a3923f1aaee4c038248489ac434ee16e292b449e1edc307b86aa24d1ada49a133d8a261
   languageName: node
   linkType: hard
 
@@ -4133,15 +4057,6 @@ __metadata:
   dependencies:
     ts-dedent: ^2.0.0
   checksum: b13a5c415e63dcbd2edf569601b30f3f80f8d1c03440fe869371da88bb1f9fb87e3da18670b62aa4acb87bec21433e2dba112d93a8293ab798be3e11f850217e
-  languageName: node
-  linkType: hard
-
-"@storybook/core-events@npm:7.5.2, @storybook/core-events@npm:^7.0.0":
-  version: 7.5.2
-  resolution: "@storybook/core-events@npm:7.5.2"
-  dependencies:
-    ts-dedent: ^2.0.0
-  checksum: 9d2891e2fc6ade1b08e11a2b62ccca4ccb7173752ef3b8c6dc1190986da0eca739d1b3a0d525ccc01639a182c7a905d6c6465323fe7447734e05d375ea0fb15f
   languageName: node
   linkType: hard
 
@@ -4341,32 +4256,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/manager-api@npm:7.5.2":
-  version: 7.5.2
-  resolution: "@storybook/manager-api@npm:7.5.2"
-  dependencies:
-    "@storybook/channels": 7.5.2
-    "@storybook/client-logger": 7.5.2
-    "@storybook/core-events": 7.5.2
-    "@storybook/csf": ^0.1.0
-    "@storybook/global": ^5.0.0
-    "@storybook/router": 7.5.2
-    "@storybook/theming": 7.5.2
-    "@storybook/types": 7.5.2
-    dequal: ^2.0.2
-    lodash: ^4.17.21
-    memoizerific: ^1.11.3
-    semver: ^7.3.7
-    store2: ^2.14.2
-    telejson: ^7.2.0
-    ts-dedent: ^2.0.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 81d8bcc653a3392800b6a8de3c31000e1ee33d2b52ba215f2a752e898fca1a05f51b3b8cf411af32eb718033be892239ab54cc876240b2d3708c2f2b47a56681
-  languageName: node
-  linkType: hard
-
 "@storybook/manager@npm:7.4.3":
   version: 7.4.3
   resolution: "@storybook/manager@npm:7.4.3"
@@ -4461,28 +4350,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/preview-api@npm:7.5.2":
-  version: 7.5.2
-  resolution: "@storybook/preview-api@npm:7.5.2"
-  dependencies:
-    "@storybook/channels": 7.5.2
-    "@storybook/client-logger": 7.5.2
-    "@storybook/core-events": 7.5.2
-    "@storybook/csf": ^0.1.0
-    "@storybook/global": ^5.0.0
-    "@storybook/types": 7.5.2
-    "@types/qs": ^6.9.5
-    dequal: ^2.0.2
-    lodash: ^4.17.21
-    memoizerific: ^1.11.3
-    qs: ^6.10.0
-    synchronous-promise: ^2.0.15
-    ts-dedent: ^2.0.0
-    util-deprecate: ^1.0.2
-  checksum: 6a1d5b7d9f67e118d22aa4e4950accdf5e30584305b509ece85091c9afd7feff3603b668533903a01928f3637dad157243465accbe7d8dcf30fecffdb4239848
-  languageName: node
-  linkType: hard
-
 "@storybook/preview@npm:7.4.3":
   version: 7.4.3
   resolution: "@storybook/preview@npm:7.4.3"
@@ -4570,20 +4437,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/router@npm:7.5.2":
-  version: 7.5.2
-  resolution: "@storybook/router@npm:7.5.2"
-  dependencies:
-    "@storybook/client-logger": 7.5.2
-    memoizerific: ^1.11.3
-    qs: ^6.10.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: bad83897534f9222ba06f9c320d2e4b4a644ba497c8d162d116d964d5c2ec5825108428043f867c2e5aa0be3935035343d22957244b5074bc96bc7c13544f829
-  languageName: node
-  linkType: hard
-
 "@storybook/telemetry@npm:7.4.3":
   version: 7.4.3
   resolution: "@storybook/telemetry@npm:7.4.3"
@@ -4628,21 +4481,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/theming@npm:7.5.2, @storybook/theming@npm:^7.0.0":
-  version: 7.5.2
-  resolution: "@storybook/theming@npm:7.5.2"
-  dependencies:
-    "@emotion/use-insertion-effect-with-fallbacks": ^1.0.0
-    "@storybook/client-logger": 7.5.2
-    "@storybook/global": ^5.0.0
-    memoizerific: ^1.11.3
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 6f63337b61af2594de00b76452fa4b6b5343619424f505ebe17674684cfa6f84c713a90106b1a91ee40af53f8fee497138f479683a2f1c232e853d96e60a697e
-  languageName: node
-  linkType: hard
-
 "@storybook/types@npm:7.4.3":
   version: 7.4.3
   resolution: "@storybook/types@npm:7.4.3"
@@ -4676,18 +4514,6 @@ __metadata:
     "@types/express": ^4.7.0
     file-system-cache: 2.3.0
   checksum: 4739a619bfa74484011574ba3ddfd43fd6b587a35cc2d4c0e24bc5ab5b6202269806ce354be1e2549ee7a19dcc334c439c70a3614d7514ab73ac7588d262e3b3
-  languageName: node
-  linkType: hard
-
-"@storybook/types@npm:7.5.2":
-  version: 7.5.2
-  resolution: "@storybook/types@npm:7.5.2"
-  dependencies:
-    "@storybook/channels": 7.5.2
-    "@types/babel__core": ^7.0.0
-    "@types/express": ^4.7.0
-    file-system-cache: 2.3.0
-  checksum: b5017ff1a3fcce274ee2cbaeb669b5d1301a2fc74f0d9842385c7d0ca2464dc074caa2a522965c03b880450b57a0572261446e67296d1086720b4b19aa6481bc
   languageName: node
   linkType: hard
 
@@ -8108,10 +7934,8 @@ __metadata:
     react-dom: 18.2.0
     react-router-dom: 6.3.0
     react-select: ^5.7.2
-    rollup-plugin-webpack-stats: ^0.2.1
     start-server-and-test: 1.14.0
     storybook: ^7.0.6
-    storybook-dark-mode: ^3.0.1
     stylelint: 14.15.0
     stylelint-config-prettier: 9.0.4
     stylelint-config-standard: 29.0.0
@@ -14906,15 +14730,6 @@ display-element-css@cfpb/storybook-addon-display-element-css:
   languageName: node
   linkType: hard
 
-"rollup-plugin-webpack-stats@npm:^0.2.1":
-  version: 0.2.1
-  resolution: "rollup-plugin-webpack-stats@npm:0.2.1"
-  peerDependencies:
-    rollup: ^3.0.0
-  checksum: e02df3462fd7ddc27630725a1012113ac93edcb650e25b676f88835ea9c5d374dca77445ecf53898b96ee2b3f97e2cbc90d433bc9f1c16b7fa071394a4039c7e
-  languageName: node
-  linkType: hard
-
 "rollup@npm:^2.25.0 || ^3.3.0, rollup@npm:^3.7.2":
   version: 3.29.2
   resolution: "rollup@npm:3.29.2"
@@ -15518,30 +15333,6 @@ display-element-css@cfpb/storybook-addon-display-element-css:
   version: 2.14.2
   resolution: "store2@npm:2.14.2"
   checksum: 6f270fc5bab99b63f45fcc7bd8b99c2714b4adf880f557ed7ffb5ed3987131251165bccde425a00928aaf044870aee79ddeef548576d093c68703ed2edec45d7
-  languageName: node
-  linkType: hard
-
-"storybook-dark-mode@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "storybook-dark-mode@npm:3.0.1"
-  dependencies:
-    "@storybook/addons": ^7.0.0
-    "@storybook/api": ^7.0.0
-    "@storybook/components": ^7.0.0
-    "@storybook/core-events": ^7.0.0
-    "@storybook/global": ^5.0.0
-    "@storybook/theming": ^7.0.0
-    fast-deep-equal: ^3.1.3
-    memoizerific: ^1.11.3
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-  peerDependenciesMeta:
-    react:
-      optional: true
-    react-dom:
-      optional: true
-  checksum: d04213c92e8a4af0035e80eb02b75b8da725ba7b1ecbfe050eb04cb4018d91394f08c8fe7c1b106c971b2047ef5a1ba776e78050ae1f6d7563cdfdba5e701a29
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3721,6 +3721,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/addons@npm:^7.0.0":
+  version: 7.5.2
+  resolution: "@storybook/addons@npm:7.5.2"
+  dependencies:
+    "@storybook/manager-api": 7.5.2
+    "@storybook/preview-api": 7.5.2
+    "@storybook/types": 7.5.2
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 9304422cbc64137e754b345d9c2f329a2b620a21a6756816268643a33259413f44122cd603159e95281c2aed316e3040d10795fdbfc726f7db99de3c0c7c5ec0
+  languageName: node
+  linkType: hard
+
+"@storybook/api@npm:^7.0.0":
+  version: 7.5.2
+  resolution: "@storybook/api@npm:7.5.2"
+  dependencies:
+    "@storybook/client-logger": 7.5.2
+    "@storybook/manager-api": 7.5.2
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    react:
+      optional: true
+    react-dom:
+      optional: true
+  checksum: d14b1ac8465018054ed74aae3bbde2f3f602f9d824f665d4dad0835cbca64606ea491ae98709ff0191cb84eabb3a63660ab76ef15ab5f2ac53031923896b361e
+  languageName: node
+  linkType: hard
+
 "@storybook/blocks@npm:7.4.3":
   version: 7.4.3
   resolution: "@storybook/blocks@npm:7.4.3"
@@ -3860,6 +3892,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/channels@npm:7.5.2":
+  version: 7.5.2
+  resolution: "@storybook/channels@npm:7.5.2"
+  dependencies:
+    "@storybook/client-logger": 7.5.2
+    "@storybook/core-events": 7.5.2
+    "@storybook/global": ^5.0.0
+    qs: ^6.10.0
+    telejson: ^7.2.0
+    tiny-invariant: ^1.3.1
+  checksum: 60dcd85317628af1dfb5c4c75a35bd317db3165cfe5c52ec16fd03628aadff693a2b5fd936d6692c5b2a7aa6929db84ac2ec3ea9de563243a5f049f0faadb23a
+  languageName: node
+  linkType: hard
+
 "@storybook/cli@npm:7.4.3":
   version: 7.4.3
   resolution: "@storybook/cli@npm:7.4.3"
@@ -3949,6 +3995,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/client-logger@npm:7.5.2":
+  version: 7.5.2
+  resolution: "@storybook/client-logger@npm:7.5.2"
+  dependencies:
+    "@storybook/global": ^5.0.0
+  checksum: d39b2fce23c3f1acd9b66241c65ccfe910dd6dc0c09d666763f6d3f9277eb04d9076e00a7528d5ff444a2c6f1d464f227f259efd20523eb6fec3eb66ff37ff86
+  languageName: node
+  linkType: hard
+
 "@storybook/codemod@npm:7.4.3":
   version: 7.4.3
   resolution: "@storybook/codemod@npm:7.4.3"
@@ -3989,6 +4044,27 @@ __metadata:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
   checksum: e286bd716535fcbfb722d9da122c2563432a2ffb8131a7b0e8be576465aa424f5aa3b9245311edd8f58a3b04aff5d99e2ac30f7d684d88c4c532bd75e8757c3b
+  languageName: node
+  linkType: hard
+
+"@storybook/components@npm:^7.0.0":
+  version: 7.5.2
+  resolution: "@storybook/components@npm:7.5.2"
+  dependencies:
+    "@radix-ui/react-select": ^1.2.2
+    "@radix-ui/react-toolbar": ^1.0.4
+    "@storybook/client-logger": 7.5.2
+    "@storybook/csf": ^0.1.0
+    "@storybook/global": ^5.0.0
+    "@storybook/theming": 7.5.2
+    "@storybook/types": 7.5.2
+    memoizerific: ^1.11.3
+    use-resize-observer: ^9.1.0
+    util-deprecate: ^1.0.2
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: ec1f9beab12e61b4a9e8f7f574cfc1ba8219d1050e499eaed262f0243a3923f1aaee4c038248489ac434ee16e292b449e1edc307b86aa24d1ada49a133d8a261
   languageName: node
   linkType: hard
 
@@ -4057,6 +4133,15 @@ __metadata:
   dependencies:
     ts-dedent: ^2.0.0
   checksum: b13a5c415e63dcbd2edf569601b30f3f80f8d1c03440fe869371da88bb1f9fb87e3da18670b62aa4acb87bec21433e2dba112d93a8293ab798be3e11f850217e
+  languageName: node
+  linkType: hard
+
+"@storybook/core-events@npm:7.5.2, @storybook/core-events@npm:^7.0.0":
+  version: 7.5.2
+  resolution: "@storybook/core-events@npm:7.5.2"
+  dependencies:
+    ts-dedent: ^2.0.0
+  checksum: 9d2891e2fc6ade1b08e11a2b62ccca4ccb7173752ef3b8c6dc1190986da0eca739d1b3a0d525ccc01639a182c7a905d6c6465323fe7447734e05d375ea0fb15f
   languageName: node
   linkType: hard
 
@@ -4256,6 +4341,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/manager-api@npm:7.5.2":
+  version: 7.5.2
+  resolution: "@storybook/manager-api@npm:7.5.2"
+  dependencies:
+    "@storybook/channels": 7.5.2
+    "@storybook/client-logger": 7.5.2
+    "@storybook/core-events": 7.5.2
+    "@storybook/csf": ^0.1.0
+    "@storybook/global": ^5.0.0
+    "@storybook/router": 7.5.2
+    "@storybook/theming": 7.5.2
+    "@storybook/types": 7.5.2
+    dequal: ^2.0.2
+    lodash: ^4.17.21
+    memoizerific: ^1.11.3
+    semver: ^7.3.7
+    store2: ^2.14.2
+    telejson: ^7.2.0
+    ts-dedent: ^2.0.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 81d8bcc653a3392800b6a8de3c31000e1ee33d2b52ba215f2a752e898fca1a05f51b3b8cf411af32eb718033be892239ab54cc876240b2d3708c2f2b47a56681
+  languageName: node
+  linkType: hard
+
 "@storybook/manager@npm:7.4.3":
   version: 7.4.3
   resolution: "@storybook/manager@npm:7.4.3"
@@ -4350,6 +4461,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/preview-api@npm:7.5.2":
+  version: 7.5.2
+  resolution: "@storybook/preview-api@npm:7.5.2"
+  dependencies:
+    "@storybook/channels": 7.5.2
+    "@storybook/client-logger": 7.5.2
+    "@storybook/core-events": 7.5.2
+    "@storybook/csf": ^0.1.0
+    "@storybook/global": ^5.0.0
+    "@storybook/types": 7.5.2
+    "@types/qs": ^6.9.5
+    dequal: ^2.0.2
+    lodash: ^4.17.21
+    memoizerific: ^1.11.3
+    qs: ^6.10.0
+    synchronous-promise: ^2.0.15
+    ts-dedent: ^2.0.0
+    util-deprecate: ^1.0.2
+  checksum: 6a1d5b7d9f67e118d22aa4e4950accdf5e30584305b509ece85091c9afd7feff3603b668533903a01928f3637dad157243465accbe7d8dcf30fecffdb4239848
+  languageName: node
+  linkType: hard
+
 "@storybook/preview@npm:7.4.3":
   version: 7.4.3
   resolution: "@storybook/preview@npm:7.4.3"
@@ -4437,6 +4570,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/router@npm:7.5.2":
+  version: 7.5.2
+  resolution: "@storybook/router@npm:7.5.2"
+  dependencies:
+    "@storybook/client-logger": 7.5.2
+    memoizerific: ^1.11.3
+    qs: ^6.10.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: bad83897534f9222ba06f9c320d2e4b4a644ba497c8d162d116d964d5c2ec5825108428043f867c2e5aa0be3935035343d22957244b5074bc96bc7c13544f829
+  languageName: node
+  linkType: hard
+
 "@storybook/telemetry@npm:7.4.3":
   version: 7.4.3
   resolution: "@storybook/telemetry@npm:7.4.3"
@@ -4481,6 +4628,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/theming@npm:7.5.2, @storybook/theming@npm:^7.0.0":
+  version: 7.5.2
+  resolution: "@storybook/theming@npm:7.5.2"
+  dependencies:
+    "@emotion/use-insertion-effect-with-fallbacks": ^1.0.0
+    "@storybook/client-logger": 7.5.2
+    "@storybook/global": ^5.0.0
+    memoizerific: ^1.11.3
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 6f63337b61af2594de00b76452fa4b6b5343619424f505ebe17674684cfa6f84c713a90106b1a91ee40af53f8fee497138f479683a2f1c232e853d96e60a697e
+  languageName: node
+  linkType: hard
+
 "@storybook/types@npm:7.4.3":
   version: 7.4.3
   resolution: "@storybook/types@npm:7.4.3"
@@ -4514,6 +4676,18 @@ __metadata:
     "@types/express": ^4.7.0
     file-system-cache: 2.3.0
   checksum: 4739a619bfa74484011574ba3ddfd43fd6b587a35cc2d4c0e24bc5ab5b6202269806ce354be1e2549ee7a19dcc334c439c70a3614d7514ab73ac7588d262e3b3
+  languageName: node
+  linkType: hard
+
+"@storybook/types@npm:7.5.2":
+  version: 7.5.2
+  resolution: "@storybook/types@npm:7.5.2"
+  dependencies:
+    "@storybook/channels": 7.5.2
+    "@types/babel__core": ^7.0.0
+    "@types/express": ^4.7.0
+    file-system-cache: 2.3.0
+  checksum: b5017ff1a3fcce274ee2cbaeb669b5d1301a2fc74f0d9842385c7d0ca2464dc074caa2a522965c03b880450b57a0572261446e67296d1086720b4b19aa6481bc
   languageName: node
   linkType: hard
 
@@ -7934,8 +8108,10 @@ __metadata:
     react-dom: 18.2.0
     react-router-dom: 6.3.0
     react-select: ^5.7.2
+    rollup-plugin-webpack-stats: ^0.2.1
     start-server-and-test: 1.14.0
     storybook: ^7.0.6
+    storybook-dark-mode: ^3.0.1
     stylelint: 14.15.0
     stylelint-config-prettier: 9.0.4
     stylelint-config-standard: 29.0.0
@@ -14729,6 +14905,15 @@ display-element-css@cfpb/storybook-addon-display-element-css:
   languageName: node
   linkType: hard
 
+"rollup-plugin-webpack-stats@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "rollup-plugin-webpack-stats@npm:0.2.1"
+  peerDependencies:
+    rollup: ^3.0.0
+  checksum: e02df3462fd7ddc27630725a1012113ac93edcb650e25b676f88835ea9c5d374dca77445ecf53898b96ee2b3f97e2cbc90d433bc9f1c16b7fa071394a4039c7e
+  languageName: node
+  linkType: hard
+
 "rollup@npm:^2.25.0 || ^3.3.0, rollup@npm:^3.7.2":
   version: 3.29.2
   resolution: "rollup@npm:3.29.2"
@@ -15332,6 +15517,30 @@ display-element-css@cfpb/storybook-addon-display-element-css:
   version: 2.14.2
   resolution: "store2@npm:2.14.2"
   checksum: 6f270fc5bab99b63f45fcc7bd8b99c2714b4adf880f557ed7ffb5ed3987131251165bccde425a00928aaf044870aee79ddeef548576d093c68703ed2edec45d7
+  languageName: node
+  linkType: hard
+
+"storybook-dark-mode@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "storybook-dark-mode@npm:3.0.1"
+  dependencies:
+    "@storybook/addons": ^7.0.0
+    "@storybook/api": ^7.0.0
+    "@storybook/components": ^7.0.0
+    "@storybook/core-events": ^7.0.0
+    "@storybook/global": ^5.0.0
+    "@storybook/theming": ^7.0.0
+    fast-deep-equal: ^3.1.3
+    memoizerific: ^1.11.3
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    react:
+      optional: true
+    react-dom:
+      optional: true
+  checksum: d04213c92e8a4af0035e80eb02b75b8da725ba7b1ecbfe050eb04cb4018d91394f08c8fe7c1b106c971b2047ef5a1ba776e78050ae1f6d7563cdfdba5e701a29
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8120,6 +8120,7 @@ __metadata:
     vite-plugin-dts: ^2.2.0
     vite-plugin-pwa: ^0.14.7
     vite-plugin-react-remove-attributes: ^1.0.3
+    vite-plugin-turbosnap: ^1.0.3
     vite-svg-loader: ^4.0.0
     vite-tsconfig-paths: 3.5.2
     vitest: 0.25.2
@@ -16997,6 +16998,13 @@ display-element-css@cfpb/storybook-addon-display-element-css:
   peerDependencies:
     vite: ^2.4.4
   checksum: 9ae11525a6b4d111a6d655b7495c319cb99dc2aadaf2f5e1a6c311b3db32a93118f0d4b314f2c039a27e21a15a644bbfafbb7fb87963afcc06912b95c505505b
+  languageName: node
+  linkType: hard
+
+"vite-plugin-turbosnap@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "vite-plugin-turbosnap@npm:1.0.3"
+  checksum: a66d09ecafef293e78a2bfceed133c3436556f8407c55be2796b5ed6ff6f80a85e1961e67382aa4e3a971f03fa33d7ee318706acc5a6c289bb7ce6a1a49293bc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Chromatic's TurboSnap feature has been failing for awhile now, or perhaps never worked correctly? This small PR dug around to figure out why, and it looks like it's a problem with the creation of the `preview-stats.json` file. The passed command line option `--webpack-stats-json` to `build-storybook` in the `package.json` appears to be correct for webpack not vite. This PR uses [Chromatic's recommended plugin](https://www.chromatic.com/docs/turbosnap/#github-pullrequest-triggers:~:text=(for%20experimental%20Vite,)) `vite-plugin-turbosnap` to create the stats file. Take a look at the screenshots and commits for a history of attempted solutions.

Resolves issue #219 

## Changes

- removes dead code `--webpack-stats-json` from `build-storybook`
- add and configure `vite-plugin-turbosnap`

## How to test this PR

This PR fixes the turbosnap configuration, but it still needs to run again with these updated deps to do diffs. I'm not sure if this is the only fix required, but it's definitely a start.

1. Does Chromatic no longer error due to a [missing webpack-stats.json file](https://github.com/cfpb/design-system-react/actions/runs/6720471476/job/18264108900#step:5:120)? Should now only be stating that it is [disabled due to deps changes](https://github.com/cfpb/design-system-react/actions/runs/6726430803/job/18282666371#step:5:57).

## Screenshots

*Before Fix*: errors in GitHub action due to missing `webpack-stats.json file`
<img width="681" alt="Screenshot 2023-11-01 at 6 11 37 PM" src="https://github.com/cfpb/design-system-react/assets/19983248/e4b09cf9-8cd3-44a1-bf33-09713d751134">

*Before Fix*: error in parsing file locally even [when forcing `webpack-stats.json` file](https://github.com/cfpb/design-system-react/pull/229/commits/c5f38b350eaa33159d31546f7d413ff1250ad62b) via `WebpackStats()` in vite. Error persists [after name change](https://github.com/cfpb/design-system-react/pull/229/commits/b490e65787df4ced46a0cbbfa4f2f395491e3c61). Parsing error tracked down to the fact that Chromatic expects a different format for the file than what vite normally produces.
<img width="1073" alt="Screenshot 2023-11-01 at 8 12 08 AM" src="https://github.com/cfpb/design-system-react/assets/19983248/b8c35327-757b-466c-b3cd-27b82c572f61">

*After Fix*: Configured the plugin, and TurboSnap is ready to go!

<img width="833" alt="Screenshot 2023-11-01 at 6 20 00 PM" src="https://github.com/cfpb/design-system-react/assets/19983248/f83dcaff-3de5-4d5d-b08b-7f3b66abcdc0">

