### PR TITLE
fix: [Links] Remove Print example

### DIFF
--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -137,30 +137,3 @@ export const JumpLinkIconLeft: Story = {
     </Link>
   )
 };
-
-export const PrintLink: Story = {
-  name: 'Printed links',
-  render: () => {
-    const linkWeight = 500;
-    const urlWeight = 300;
-
-    return (
-      <p>
-        Here&apos;s the{' '}
-        <a
-          href='https://consumerfinance.gov/about-us/blog'
-          style={{ fontWeight: linkWeight }}
-        >
-          link style
-          <span
-            style={{ fontWeight: urlWeight, borderBottom: '1px solid #ffffff' }}
-          >
-            {' '}
-            (cfpb.gov/about-us/blog)
-          </span>
-        </a>{' '}
-        when printed.
-      </p>
-    );
-  }
-};


### PR DESCRIPTION
Closes #215 

@natalia-fitzgerald Final adjustment to the Links documentation. 

@billhimmelsbach @shindigira Please ignore.

## Changes

- Remove the `Print links` example
