### PR TITLE
design(banner): final design review for Banner (US gov)

### DIFF
--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -9,6 +9,8 @@ addons.setConfig({
         // Sentence case
         let newName = name.toLowerCase();
         newName = newName[0].toUpperCase() + newName.substr(1);
+        // Preserve US (United States) initials - would cause problems for 'us' as a pronoun
+        newName = newName.replace(/\b[Uu]s\b/, 'US');
         return newName;
       }
       return name;

--- a/src/components/Banner/Banner.stories.tsx
+++ b/src/components/Banner/Banner.stories.tsx
@@ -37,7 +37,15 @@ const UnclickableLink = ({
   </span>
 );
 
-export const BannerWithLinks: Story = {
+export const USGovBanner: Story = {
+  render: properties => <Banner {...properties} />,
+  args: {
+    links: []
+  }
+};
+USGovBanner.storyName = 'US gov banner';
+
+export const USGovBannerWithLinks: Story = {
   render: properties => <Banner {...properties} />,
   args: {
     links: [
@@ -53,9 +61,10 @@ export const BannerWithLinks: Story = {
     ]
   }
 };
+USGovBannerWithLinks.storyName = 'US gov banner with generic links';
 
-export const CFGovEdition: Story = {
-  ...BannerWithLinks,
+export const USGovBannerWithCFGovLinks: Story = {
+  ...USGovBannerWithLinks,
   args: {
     links: AllLanguageCodes.filter(code => code !== 'en').map(code => (
       <UnclickableLink key={code}>
@@ -71,3 +80,4 @@ export const CFGovEdition: Story = {
     )
   }
 };
+USGovBannerWithCFGovLinks.storyName = 'US gov banner with cf.gov links';

--- a/src/components/Banner/Banner.stories.tsx
+++ b/src/components/Banner/Banner.stories.tsx
@@ -61,7 +61,7 @@ export const USGovBannerWithLinks: Story = {
     ]
   }
 };
-USGovBannerWithLinks.storyName = 'US gov banner with generic links';
+USGovBannerWithLinks.storyName = 'US gov banner (with generic links)';
 
 export const USGovBannerWithCFGovLinks: Story = {
   ...USGovBannerWithLinks,
@@ -80,4 +80,4 @@ export const USGovBannerWithCFGovLinks: Story = {
     )
   }
 };
-USGovBannerWithCFGovLinks.storyName = 'US gov banner with cf.gov links';
+USGovBannerWithCFGovLinks.storyName = 'US gov banner (cf.gov)';

--- a/src/components/Banner/Banner.stories.tsx
+++ b/src/components/Banner/Banner.stories.tsx
@@ -4,7 +4,7 @@ import { Banner } from '~/src/index';
 import { AllLanguageCodes, LanguageLink } from './BannerLanguageLink';
 
 const meta: Meta<typeof Banner> = {
-  title: 'Components (Draft)/Banners',
+  title: 'Components (Verified)/Banner (US gov)',
   component: Banner,
   argTypes: {}
 };

--- a/src/components/Banner/Banner.stories.tsx
+++ b/src/components/Banner/Banner.stories.tsx
@@ -45,26 +45,7 @@ export const USGovBanner: Story = {
 };
 USGovBanner.storyName = 'US gov banner';
 
-export const USGovBannerWithLinks: Story = {
-  render: properties => <Banner {...properties} />,
-  args: {
-    links: [
-      <UnclickableLink key='Link 1'>
-        <a href='/link'>Link 1</a>
-      </UnclickableLink>,
-      <UnclickableLink key='Link 2'>
-        <a href='/link'>Link 2</a>
-      </UnclickableLink>,
-      <UnclickableLink key='Link 3'>
-        <a href='/link'>Link 3</a>
-      </UnclickableLink>
-    ]
-  }
-};
-USGovBannerWithLinks.storyName = 'US gov banner (with generic links)';
-
 export const USGovBannerWithCFGovLinks: Story = {
-  ...USGovBannerWithLinks,
   args: {
     links: AllLanguageCodes.filter(code => code !== 'en').map(code => (
       <UnclickableLink key={code}>
@@ -81,3 +62,22 @@ export const USGovBannerWithCFGovLinks: Story = {
   }
 };
 USGovBannerWithCFGovLinks.storyName = 'US gov banner (cf.gov)';
+
+export const USGovBannerWithLinks: Story = {
+  ...USGovBannerWithCFGovLinks,
+  render: properties => <Banner {...properties} />,
+  args: {
+    links: [
+      <UnclickableLink key='Link 1'>
+        <a href='/link'>Link 1</a>
+      </UnclickableLink>,
+      <UnclickableLink key='Link 2'>
+        <a href='/link'>Link 2</a>
+      </UnclickableLink>,
+      <UnclickableLink key='Link 3'>
+        <a href='/link'>Link 3</a>
+      </UnclickableLink>
+    ]
+  }
+};
+USGovBannerWithLinks.storyName = 'US gov banner (with generic links)';

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -31,11 +31,18 @@ const TelephoneLink = ({
 };
 
 /**
- * CFGov's Global Eyebrow component
+ *The US gov banner identifies official websites of government organizations in the United States. It helps visitors understand whether a website is official and secure.
+ *
+ * Source: <a href='https://cfpb.github.io/design-system/components/banner-us-gov' target='_blank'> https://cfpb.github.io/design-system/components/banner-us-gov</a>
  */
 export const Banner = ({
   isHorizontal = true,
-  tagline = 'This is a tagline',
+  tagline = (
+    <>
+      An official website of the{' '}
+      <span className='u-nowrap'>United States government</span>
+    </>
+  ),
   phoneNumber,
   links = [],
   className,


### PR DESCRIPTION
Makes changes to Banner (US gov) to move to verified.
![Screenshot 2023-11-21 at 11 26 43 AM](https://github.com/cfpb/design-system-react/assets/19983248/060c13c4-c0d8-4448-b8aa-cc2287fc31e0)

Note: Made the default tagline for the Banner (US gov) [match the text and markup](https://github.com/cfpb/design-system-react/pull/246/files#diff-f9882edc8324cf88b43076801e6c25a605f41b89e1e3bf19a04c7eb2c05619a7R40) of the banner displayed in the DS. This better matches the DS, and avoids having to remember to wrap the "United States government" part of the tagline in a span with class `u-nowrap` in the instances it occurs.

Closes #213 

## Verification checklist
#### For existing components 
### Verify the CFPB Design System (React) component against the CFPB Design System
- [x] Has component intro text copied from the DS page
- [x] Has source link to component's DS page (ex - Source: https://cfpb.github.io/design-system/components/banner-notification)
- [x] Each DS variant is implemented as a separate story
  **- Note: the design system only includes one use case without links, our examples in the DSR also include one with generic links and one with the implementation on cf.gov**
  - [x] Story name should be sentence case (ex. List Link => List link)
  - [x] Naming is consistent with the DS
  - [x] Same component names, same placeholder text, etc.
- [x] Order of stories matches between DS/DSR
- [x] Component is built correctly
  - [x] Visually compare DSR implementation to DS
  - [x] Verify that React renders the HTML markup the same as in the DS (if at all possible)
  - [x] Verify that DS classes (organisms, molecules, atoms) are used, as opposed to styles defined in DSR
- [x] Check to see if the applied CSS styles match the Specs in the DS if applicable (message @natalia-fitzgerald if it does not)
- [x] Manual visual review has been conducted and component has passed this review

#### ~For new components~
- ~[ ] All steps for existing components plus the following steps~
- ~[ ] The new component has been added to the CFPB Design System OR~
- ~[ ] The CFPB Design System maintainers have been alerted that there is a new component that must be added to the system~
- ~[ ] Documentation has been written for the new component (this is not a blocker for moving a component to verified)~

### Run accessibility checks 
- [x] Component is keyboard-friendly (navigable with tab, space, enter, arrow keys, etc.)
- [x] Component does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)
**Note: links don't go anywhere in the example, which is fine**
- [x] Component is screen reader friendly ([screen reader testing demo](https://drive.google.com/file/d/189A9Wx_T1C49TES5ZtYXlIFbJbLP472p/view))
  - [x] Is all the meaningful visual information and text of the component conveyed by the screen reader? (text, non-decorative image descriptions, etc.)
  - [x] When interacting with the component using a screen reader, do you have all the information you need to use it? (selected vs unselected, button vs link, expanded vs collapsed, etc.)
  - [x] Does the component have similar screen reader behavior as the sample components in WCAG, the CFPB design system, WebAIM, or similar accessibility examples?
- [x] For reference: [CFPB manual web accessibility audit](https://cfpb.github.io/design-system/guidelines/accessibility-audit-tools#cfpb-manual-web-accessibility-audit-1) 

### Verify component unit tests
- [x] Verify component unit tests are implemented and passing - 85% or greater (ex: `yarn vitest Button`)

### Conduct Code PR review
- [ ] [Submit PR](https://github.com/cfpb/design-system-react/pull/207) with any necessary changes for code review by frontend devs and copy completed checklist above into PR description
**I'm going to skip this step to get it front of Natalia**
  
### Conduct Design PR review
- [x] Prepare component to be reviewed and approved by UI/UX
  - [x] [Create a PR](https://github.com/cfpb/design-system-react/pull/218) with the name: `design(XXXX): final design review for XXXX component`
  - [x] Change [only component's](https://github.com/cfpb/design-system-react/pull/218/commits/f745c3c9043f9ab1e04c3150122d93b2df4e54a3) status from `Draft` to `Verified` in Storybook
  - [x] Apply GitHub label "[design](https://github.com/cfpb/design-system-react/labels/design)"
  - [x] Add @natalia-fitzgerald as additional reviewer
  - [x] Ping @natalia-fitzgerald on Mattermost when ready

### Verify component
- [ ] Merge when design review completed to finish component verification 🎉