### PR TITLE
fix: [TextIntroduction] Export component from /src/index

### DIFF
--- a/src/components/TextIntroduction/TextIntroduction.stories.tsx
+++ b/src/components/TextIntroduction/TextIntroduction.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta } from '@storybook/react';
-import { TextIntroduction } from './TextIntroduction';
+import { TextIntroduction } from '~/src/index';
 import placeholders from './testHelpers';
 
 const meta: Meta<typeof TextIntroduction> = {

--- a/src/components/TextIntroduction/TextIntroduction.test.tsx
+++ b/src/components/TextIntroduction/TextIntroduction.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
-import { TextIntroduction } from './TextIntroduction';
+import { TextIntroduction } from '~/src/index';
 import placeholders from './testHelpers';
 
 describe('<TextIntroduction />', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,5 +42,6 @@ export { RadioButton } from './components/RadioButton/RadioButton';
 export { Table } from './components/Table/Table';
 export { Tagline } from './components/Tagline/Tagline';
 export { TextInput } from './components/TextInput/TextInput';
+export { TextIntroduction } from './components/TextIntroduction/TextIntroduction';
 export { WellContainer, WellContent } from './components/Well/Well';
 


### PR DESCRIPTION
Closes #248 

- Fixes an error that was introduced during git conflict resolution.  
- Import component from root `index.ts` to ensure it is correctly exposed to end users.