### PR TITLE
[Button] Keep destructive action inline on mobile

### DIFF
--- a/src/components/Buttons/Buttons.stories.tsx
+++ b/src/components/Buttons/Buttons.stories.tsx
@@ -60,7 +60,7 @@ export const DestructiveAction: Story = {
     ...Primary.args,
     label: 'Destructive action',
     appearance: 'warning',
-    size: 'full',
+    size: 'default',
     asLink: true
   },
   render: arguments_ => (


### PR DESCRIPTION
Closes #252 

## Changes

- Remove responsive styling from Destructive Action

## How to test this PR

1. Visit [Button](https://deploy-preview-253--cfpb-design-system-react.netlify.app/?path=/story/components-verified-buttons--destructive-action)
2. Use your preferred method to view the page at a mobile width. 
3. Observe that buttons stay inline, provided there is horizontal space to accommodate their content. 

## Screenshots
<img width="309" alt="actions-always-inline-mobile" src="https://github.com/cfpb/design-system-react/assets/2592907/c510d11d-f733-47c0-a072-6afcdc1b4b34">
