### PR TITLE
Fix: Leaking styles & unreadable code blocks

### DIFF
--- a/src/assets/styles/_shared.less
+++ b/src/assets/styles/_shared.less
@@ -44,7 +44,8 @@
   Make code block plain-text readable (workaround since we can't change code highlighting theme) 
   https://github.com/storybookjs/storybook/issues/9641
   */
-  pre.prismjs {
+  pre {
+    background-color: #2b2b2b;
     color: white;
   }
 }
@@ -53,7 +54,7 @@
 Apply a global line-height that doesn't interfere with component Stories 
 that have their own line-height settings. 
 */
-pre.prismjs,
+pre,
 #storybook-docs :where(p:not(.sb-story *)) {
   line-height: 22px !important;
 }

--- a/src/assets/styles/_shared.less
+++ b/src/assets/styles/_shared.less
@@ -54,13 +54,6 @@ Apply a global line-height that doesn't interfere with component Stories
 that have their own line-height settings. 
 */
 pre.prismjs,
-:where(p:not(.sb-story *, #storybook-root *)) {
-  line-height: 22px !important;
-}
-
-/* 
-Apply a global line-height that doesn't interfere with component Stories that have their own line-height settings. 
-*/
-:where(p:not(.sb-story *, #storybook-root *)){
+#storybook-docs :where(p:not(.sb-story *)) {
   line-height: 22px !important;
 }


### PR DESCRIPTION
Closes #247

## Changes

1) Restrict `line-height` to Storybook pages. This setting is intended to adjust line-height for the intro paragraphs and other non-story paragraph text on Overview pages, such as the highlighted block in the following screenshot.
  - ![Screenshot 2023-11-29 at 4 59 39 PM](https://github.com/cfpb/design-system-react/assets/2592907/63374a27-8d3c-4f9a-b372-fb8eca1be187)
  - [Source](https://cfpb.github.io/design-system-react/?path=/docs/guides-introduction--overview)
2) Fix white text on white background for non-Storybook generated `pre` blocks

## Screenshots

|Before|After|
|---|---|
|![Screenshot 2023-11-29 at 4 53 13 PM](https://github.com/cfpb/design-system-react/assets/2592907/49f9c52c-c57c-43d2-9da9-8971d5f5afc1)|![Screenshot 2023-11-29 at 4 53 21 PM](https://github.com/cfpb/design-system-react/assets/2592907/cd94c105-f5fc-4673-a0c9-e9ed3f99a5ae)|
