### PR TITLE
fix: More sensible usePagination defaults

### DIFF
--- a/src/components/Pagination/usePagination.test.tsx
+++ b/src/components/Pagination/usePagination.test.tsx
@@ -28,8 +28,8 @@ describe('usePagination', () => {
     expect(visibleRows.length).toBe(NUMBER_ROWS);
 
     // Returns placeholder Pagination props
-    expect(paginationProperties.page).toBe(0);
-    expect(paginationProperties.pageCount).toBe(0);
+    expect(paginationProperties.page).toBe(ONE);
+    expect(paginationProperties.pageCount).toBe(ONE);
   });
 
   it('Returns all rows when cannot paginate (rows.length < perPage)', () => {
@@ -43,8 +43,8 @@ describe('usePagination', () => {
     expect(visibleRows.length).toBe(4);
 
     // Returns placeholder Pagination props
-    expect(paginationProperties.page).toBe(0);
-    expect(paginationProperties.pageCount).toBe(0);
+    expect(paginationProperties.page).toBe(ONE);
+    expect(paginationProperties.pageCount).toBe(ONE);
   });
 
   it('Returns returns first page of content by default when paginating', () => {

--- a/src/components/Pagination/usePagination.tsx
+++ b/src/components/Pagination/usePagination.tsx
@@ -41,8 +41,8 @@ export const usePagination = ({
   }, [page, pageCount, perPage]);
 
   const defaultProperties: PaginationProperties = {
-    page: 0,
-    pageCount: 0,
+    page: MIN_PAGE,
+    pageCount: MIN_PAGE,
     onClickNext: noOp,
     onClickPrevious: noOp,
     onClickGo: noOp


### PR DESCRIPTION
Closes #266

## Changes

- Update defaults from `usePagination` to use the `MIN_PAGE` value instead of `0`

## How to test this PR

1. yarn test Pagination
2. yarn test Table

## Screenshots
`Before` pagination showed that we were on page `0 of 0`, `After` we see page `1 of 1` which feels more reasonable. 

|Before|After|
|---|---|
|![Screenshot 2023-12-05 at 10 07 25 AM](https://github.com/cfpb/design-system-react/assets/2592907/bc0dcce4-dd2e-4825-bccf-c5168965b378)|![Screenshot 2023-12-05 at 10 07 38 AM](https://github.com/cfpb/design-system-react/assets/2592907/2173d5b2-e31c-4dd0-a358-008190ec26e3)|

