### PR TITLE
fix: [Layout] Remove negative margin-right that was causing sidebar overflow

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -2,6 +2,7 @@ import { LayoutContent } from './LayoutContent';
 import { LayoutMain } from './LayoutMain';
 import { LayoutSidebar } from './LayoutSidebar';
 import { LayoutWrapper } from './LayoutWrapper';
+import './layout.less';
 
 export default {
   Content: LayoutContent,

--- a/src/components/Layout/layout.less
+++ b/src/components/Layout/layout.less
@@ -1,0 +1,7 @@
+// Override Design System styles that cause content to overflow sidebar boundaries
+@media only all and (min-width: 37.5625em) {
+  .content__2-1 .content_main,
+  .content__1-3 .content_sidebar {
+    margin-right: 0 !important;
+  }
+}


### PR DESCRIPTION
Closes #270

## Changes
- Removes negative margin-right that was causing sidebar overflow

## Notes
- The overflow of the sidebar's `border` (yellow portion in the screenshots) matches what we see in the Design System, so I've left that unchanged. 

## Screenshots
|Layout|Before|After|
|---|---|---|
|1-3|![1-3-before](https://github.com/cfpb/design-system-react/assets/2592907/6638800f-f0d4-4252-b8fa-b722ddc2c149)|![1-3-after](https://github.com/cfpb/design-system-react/assets/2592907/f2ce5ee7-d226-4616-9bfd-fe1625573453)|
|2-1|![2-1-before](https://github.com/cfpb/design-system-react/assets/2592907/14bb1077-4015-45ea-8b49-08386077a59c)|![2-1-after](https://github.com/cfpb/design-system-react/assets/2592907/0cfd2a7c-84cd-497b-b2c6-c72a7fedac36)|


