### PR TITLE
wip fix: [AlertFieldLevel] margin 0.5em, icon vertical centering issue, TextInput changes, Checkbox changes

### DIFF
--- a/src/components/Alert/Alert.css
+++ b/src/components/Alert/Alert.css
@@ -5,11 +5,12 @@
   position: absolute;
 }
 
-.m-notification:not(.m-notification__error, .m-notification__success, .m-notification__warning) .cf-icon-svg {
+.m-notification:not(.m-notification__error, .m-notification__success, .m-notification__warning)
+  .cf-icon-svg {
   fill: #5a5d61;
 }
 
-.cf-icon-svg-wrapper+.m-notification_content {
+.cf-icon-svg-wrapper + .m-notification_content {
   padding-left: 1.5625em;
 }
 
@@ -20,4 +21,14 @@
 
 .m-notification .m-list .cf-icon-svg-wrapper .cf-icon-svg {
   fill: currentcolor;
+}
+
+.a-alertfieldlevel-text {
+  display: inline;
+  margin-left: 0.5em;
+}
+
+.a-alertfieldlevel-container {
+  display: flex;
+  align-items: center;
 }

--- a/src/components/Alert/AlertFieldLevel.tsx
+++ b/src/components/Alert/AlertFieldLevel.tsx
@@ -1,5 +1,6 @@
 import type { JSXElement } from '~/src/types/jsxElement';
 import { Icon } from '../Icon/Icon';
+import './Alert.css';
 
 export type AlertFieldLevelType = 'error' | 'info' | 'success' | 'warning';
 
@@ -41,12 +42,15 @@ export const AlertFieldLevel = ({
 
   return (
     <div
-      className={`a-form-alert a-form-alert${AlertFieldLevelClass[status]}`}
+      className={`a-form-alert a-form-alert${AlertFieldLevelClass[status]} a-alertfieldlevel-container`}
       role='alert'
       {...properties}
     >
       <Icon name={MapTypeToIconName[status]} alt={status} withBg />
-      <span className='a-form-alert_text' data-testid='message'>
+      <span
+        className='a-form-alert_text a-alertfieldlevel-text'
+        data-testid='message'
+      >
         {message}
       </span>
     </div>


### PR DESCRIPTION
closes #276 

# POSTPONED
Will require a preceding DS approval before a DSR approval.

## TODO
- [ ] Change Margin between icon and text to 5px in AlertFieldLevel
- [ ] fix the vertically align icon in Alert (not fieldlevel) (Delay LOW PRIORITY: [context](figma comment that we will revisit this change later))
- [ ] vertically align Checkbox and label text, margin with text also
- [ ] Error dotted line around checkbox/textinput
- [ ] textinput/checkbox: red outline, get rid of hover blue, focus color should be same as border (e.g. error red)
Dark hover colors: https://github.com/cfpb/design-system/issues/1881#issuecomment-1896959910

## Changes
- Sets text to inline instead of block
- Vertically aligns the icon with the text
- Sets the margin between the icon and the text to be [8px (0.5em)](https://github.com/cfpb/sbl-frontend/pull/146#pullrequestreview-1814660899)

## Screenshots
|Before|After|
|---|---|
|<img width="888" alt="Screenshot 2024-01-11 at 5 50 26 AM" src="https://github.com/cfpb/design-system-react/assets/13324863/fa64bebb-fd21-4745-bb74-4fc4c99c1db9">|<img width="867" alt="Screenshot 2024-01-11 at 5 50 35 AM" src="https://github.com/cfpb/design-system-react/assets/13324863/a8932cee-ade8-46e9-88bb-3ae4ba0c652d">|
