### PR TITLE
[Checkbox] Allows spread properties to reach the actual checkbox element

### DIFF
--- a/src/components/Checkbox/Checkbox.test.tsx
+++ b/src/components/Checkbox/Checkbox.test.tsx
@@ -6,6 +6,7 @@ import { CheckboxTestWrapper } from './Checkbox.utils';
 const id = 'default';
 const label = 'this is a label';
 const testId = `${id}-container`;
+const inputTestId = `${id}-input`;
 
 const attributeAria = 'aria-checked';
 const attributeClass = 'class';
@@ -18,7 +19,7 @@ describe('Checkbox', () => {
     const testTitle = 'test-title';
 
     render(<Checkbox {...defaultProps} title={testTitle} />);
-    const checkbox = screen.getByTestId(testId);
+    const checkbox = screen.getByTestId(inputTestId);
 
     expect(checkbox).toBeInTheDocument();
     expect(checkbox).toHaveAttribute(attributeTitle, testTitle);

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -65,7 +65,7 @@ export const Checkbox = ({
   onChange,
   status,
   ...properties
-}: CheckboxProperties): ReactElement => {
+}: CheckboxProperties & JSX.IntrinsicElements['input']): ReactElement => {
   const onChangeHandler = useCallback(
     (event: ChangeEvent<HTMLInputElement>): void => {
       onChange?.(event);
@@ -91,13 +91,13 @@ export const Checkbox = ({
         checked={checked}
         aria-checked={checked}
         aria-labelledby={`${id}-label`}
-        data-testid={`${id}-input`}
         name={name ?? id}
-        className={classnames(['a-checkbox', inputClassName])}
         ref={inputRef}
         disabled={disabled}
         onChange={onChangeHandler}
         {...properties}
+        data-testid={`${id}-input`}
+        className={classnames(['a-checkbox', inputClassName])}
       />
       <Label
         id={`${id}-label`}


### PR DESCRIPTION
closes #305 

## Use case
- Properties used by `zod` and `react-hook-form` need be placed in the actual Checkbox (input element).

## Changes
- Allows spread properties to reach the actual checkbox element

## How to Test
- I believe just code inspection should be sufficient.