### PR TITLE
fix: [Icon] Restrict wrapper height to match icon height

### DIFF
--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -92,8 +92,9 @@ export const Icon = ({
   const iconHtml = `${icon}`.replace('<svg', `<svg ${iconAttributes} `);
 
   return (
-    <span
+    <div
       className='cf-icon-svg-wrapper'
+      style={{ display: 'inline-block', height: '1.1875em' }}
       dangerouslySetInnerHTML={{ __html: iconHtml }}
       {...others}
     />


### PR DESCRIPTION
This PR eliminates the extra height we were seeing from the `.cf-icon-svg-wrapper` elements...but it still doesn't seem to correct the odd alignment issues.

Other things I've tried:
- Changing the `.cf-icon-svg`'s `vertical-align` property.  The only value that seems like it may be an improvement is `vertical-align: sub`, which shifts icons down 1 or 2 pixels. 

## Changes

-

## How to test this PR

1.

## Screenshots

## Notes

-
