### PR TITLE
feat(icon): add aria-label, aria-labelledby, aria-describedby, isPresentational

### DIFF
--- a/src/components/Footer/BackToTop.tsx
+++ b/src/components/Footer/BackToTop.tsx
@@ -9,6 +9,6 @@ export const BackToTop = (): JSX.Element => (
     href='#'
   >
     Back to top
-    <Icon name='arrow-up' />
+    <Icon name='arrow-up' isPresentational />
   </a>
 );

--- a/src/components/Footer/FooterCfGov.tsx
+++ b/src/components/Footer/FooterCfGov.tsx
@@ -30,7 +30,7 @@ export const FooterCfGov = (): JSX.Element => {
       data-pretty-href='https://www.facebook.com/CFPB'
       href='/external-site/?ext_url=https%3A%2F%2Fwww.facebook.com%2FCFPB&amp;signature=mLDxq_fH8p2jVLrkPngPqkmwdsl_JEMSCoqZ74gLcCY'
     >
-      <Icon name='facebook' withBg />
+      <Icon name='facebook' isPresentational withBg />
     </a>,
     <a
       key='twitter'
@@ -38,7 +38,7 @@ export const FooterCfGov = (): JSX.Element => {
       data-pretty-href='https://twitter.com/CFPB'
       href='/external-site/?ext_url=https%3A%2F%2Ftwitter.com%2FCFPB&amp;signature=2v_Kj1FtlY2ztSvBVUEZAzTb4Mrz1xDgzU7E4914qyo'
     >
-      <Icon name='twitter' withBg />
+      <Icon name='twitter' isPresentational withBg />
     </a>,
     <a
       key='linkedin'
@@ -46,7 +46,7 @@ export const FooterCfGov = (): JSX.Element => {
       data-pretty-href='https://www.linkedin.com/company/consumer-financial-protection-bureau'
       href='/external-site/?ext_url=https%3A%2F%2Fwww.linkedin.com%2Fcompany%2Fconsumer-financial-protection-bureau&amp;signature=cz77eS0N43ZshZvOXukyBB85_qSkkDBs7o0q5Ikf5m0'
     >
-      <Icon name='linkedin' withBg />
+      <Icon name='linkedin' isPresentational withBg />
     </a>,
     <a
       key='youtube'
@@ -54,7 +54,7 @@ export const FooterCfGov = (): JSX.Element => {
       data-pretty-href='https://www.youtube.com/user/cfpbvideo'
       href='/external-site/?ext_url=https%3A%2F%2Fwww.youtube.com%2Fuser%2Fcfpbvideo&amp;signature=ldBCE9dfMS_pke0Gy053F8Li0bUMA6CpBpTodqahPSA'
     >
-      <Icon name='youtube' alt='Visit us on YouTube' withBg />
+      <Icon name='youtube' alt='Visit us on YouTube' isPresentational withBg />
     </a>,
     <a
       key='flickr'
@@ -62,7 +62,7 @@ export const FooterCfGov = (): JSX.Element => {
       data-pretty-href='https://www.flickr.com/photos/cfpbphotos'
       href='/external-site/?ext_url=https%3A%2F%2Fwww.flickr.com%2Fphotos%2Fcfpbphotos&amp;signature=GbqC6nvI0a2NHWTQqKaK2EOdJBMbQ9D6sv7J1TXR1oI'
     >
-      <Icon name='flickr' alt='Visit us on Flickr' withBg />
+      <Icon name='flickr' alt='Visit us on Flickr' isPresentational withBg />
     </a>
   ];
 
@@ -117,7 +117,11 @@ export const FooterCfGov = (): JSX.Element => {
   const linksCol3 = [
     <a key='usa-gov' className='a-link a-link__icon' href='https://usa.gov/'>
       <span className='a-link_text'>USA.gov</span>
-      <Icon name='external-link' alt='External link' />
+      <Icon
+        ariaLabel='External link'
+        name='external-link'
+        alt='External link'
+      />
     </a>,
     <a
       key='inspector'
@@ -125,7 +129,11 @@ export const FooterCfGov = (): JSX.Element => {
       href='https://www.federalreserve.gov/oig/default.htm'
     >
       <span className='a-link_text'>Office of Inspector General</span>
-      <Icon name='external-link' alt='External link' />
+      <Icon
+        ariaLabel='External link'
+        name='external-link'
+        alt='External link'
+      />
     </a>
   ];
 

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -96,8 +96,8 @@ export const Icon = ({
 
   const iconAttributes = [
     `class="${classNames(classes)}"`,
-    isPresentational ? 'role="img"' : '',
-    isPresentational ? `alt="${alt ?? name}"` : '',
+    isPresentational ? '' : 'role="img"',
+    isPresentational ? '' : `alt="${alt ?? name}"`,
     isPresentational ? 'aria-hidden="true"' : '',
     ariaLabel ? `aria-label="${ariaLabel}"` : '',
     ariaLabelledby ? `aria-labelledby="${ariaLabelledby}"` : '',

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -97,6 +97,8 @@ export const Icon = ({
     `style="font-size: ${sizeMap[size] || size}"`
   ].join(' ');
 
+  console.log('ariaLabelledby :>>', ariaLabelledby);
+
   const iconHtml = `${icon}`.replace('<svg', `<svg ${iconAttributes} `);
 
   return (

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -52,6 +52,7 @@ const getShapeModifier = (name: string, withBg: boolean): string => {
 interface IconProperties {
   name: string;
   alt?: string;
+  ariaLabel?: string;
   ariaLabelledby?: string;
   ariaDescribedby?: string;
   withBg?: boolean;
@@ -65,6 +66,7 @@ interface IconProperties {
  *
  * @param name Canonical icon name
  * @param alt Alt text for image
+ * @param ariaLabel Labels the SVG for accessibility
  * @param ariaLabelledby ID of element that labels the SVG for accessibility
  * @param ariaDescribedby ID of element that describes the SVG for accessibility
  * @param withBg With background?
@@ -74,6 +76,7 @@ interface IconProperties {
 export const Icon = ({
   name,
   alt,
+  ariaLabel = '',
   ariaLabelledby = '',
   ariaDescribedby = '',
   withBg = false,
@@ -92,12 +95,11 @@ export const Icon = ({
     `class="${classNames(classes)}"`,
     'role="img"',
     `alt="${alt ?? name}"`,
+    ariaLabel ? `aria-label="${ariaLabel}"` : '',
     ariaLabelledby ? `aria-labelledby="${ariaLabelledby}"` : '',
     ariaDescribedby ? `aria-describedby="${ariaDescribedby}"` : '',
     `style="font-size: ${sizeMap[size] || size}"`
   ].join(' ');
-
-  console.log('ariaLabelledby :>>', ariaLabelledby);
 
   const iconHtml = `${icon}`.replace('<svg', `<svg ${iconAttributes} `);
 

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -52,6 +52,8 @@ const getShapeModifier = (name: string, withBg: boolean): string => {
 interface IconProperties {
   name: string;
   alt?: string;
+  ariaLabelledby?: string;
+  ariaDescribedby?: string;
   withBg?: boolean;
   size?: string;
 }
@@ -63,6 +65,8 @@ interface IconProperties {
  *
  * @param name Canonical icon name
  * @param alt Alt text for image
+ * @param ariaLabelledby ID of element that labels the SVG for accessibility
+ * @param ariaDescribedby ID of element that describes the SVG for accessibility
  * @param withBg With background?
  * @param size Match the icon size to a specified HTML element or provide a custom size. By default the icon size is determined by it's parent element's font-size.
  * @returns ReactElement | null
@@ -70,6 +74,8 @@ interface IconProperties {
 export const Icon = ({
   name,
   alt,
+  ariaLabelledby = '',
+  ariaDescribedby = '',
   withBg = false,
   size = 'inherit',
   ...others
@@ -86,6 +92,8 @@ export const Icon = ({
     `class="${classNames(classes)}"`,
     'role="img"',
     `alt="${alt ?? name}"`,
+    `aria-labelledby=${ariaLabelledby}`,
+    `aria-describedby=${ariaDescribedby}`,
     `style="font-size: ${sizeMap[size] || size}"`
   ].join(' ');
 

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -55,6 +55,7 @@ interface IconProperties {
   ariaLabel?: string;
   ariaLabelledby?: string;
   ariaDescribedby?: string;
+  isPresentational?: boolean;
   withBg?: boolean;
   size?: string;
 }
@@ -69,6 +70,7 @@ interface IconProperties {
  * @param ariaLabel Labels the SVG for accessibility
  * @param ariaLabelledby ID of element that labels the SVG for accessibility
  * @param ariaDescribedby ID of element that describes the SVG for accessibility
+ * @param isPresentational Is SVG purely presentational and should be ignored by screen readers?
  * @param withBg With background?
  * @param size Match the icon size to a specified HTML element or provide a custom size. By default the icon size is determined by it's parent element's font-size.
  * @returns ReactElement | null
@@ -79,6 +81,7 @@ export const Icon = ({
   ariaLabel = '',
   ariaLabelledby = '',
   ariaDescribedby = '',
+  isPresentational = false,
   withBg = false,
   size = 'inherit',
   ...others
@@ -93,8 +96,9 @@ export const Icon = ({
 
   const iconAttributes = [
     `class="${classNames(classes)}"`,
-    'role="img"',
-    `alt="${alt ?? name}"`,
+    isPresentational ? 'role="img"' : '',
+    isPresentational ? `alt="${alt ?? name}"` : '',
+    isPresentational ? 'aria-hidden="true"' : '',
     ariaLabel ? `aria-label="${ariaLabel}"` : '',
     ariaLabelledby ? `aria-labelledby="${ariaLabelledby}"` : '',
     ariaDescribedby ? `aria-describedby="${ariaDescribedby}"` : '',

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -92,8 +92,8 @@ export const Icon = ({
     `class="${classNames(classes)}"`,
     'role="img"',
     `alt="${alt ?? name}"`,
-    `aria-labelledby=${ariaLabelledby}`,
-    `aria-describedby=${ariaDescribedby}`,
+    ariaLabelledby ? `aria-labelledby="${ariaLabelledby}"` : '',
+    ariaDescribedby ? `aria-describedby="${ariaDescribedby}"` : '',
     `style="font-size: ${sizeMap[size] || size}"`
   ].join(' ');
 


### PR DESCRIPTION
Currently we use `alt` as the accessibility feature on `Icon`s that serve as images with the role `img`, but `alt` [isn't quite right for a `svg`](https://accessibilityinsights.io/info-examples/web/svg-img-alt/). So we have a couple options, and we can pick one of these depending on the use case: 

Instead of `alt`, the `svg` should have one of these:
  - a `<title>` + `<description>` as a child of the `<svg>` 
  - the `svg` could have an `aria-labelledby` and an optional `aria-describedby`
  - just an `aria-label`  for simple `svg`s 
  
I'd prefer to use title/description, but it would be tricker to manipulate/inject that into the raw html that this component relies on. I've allowed `aria-labelledby` and an optional `aria-describedby` in case people want them for more complicated `svg`s, but `aria-label` should serve most of our needs.

For some cases, the `svg` doesn't provide any additional information than the anchor link it's part of, in that case we want to use the new `isPresentational` to not announce the`svg` for users using screen readers.

## Current behavior
- `alt` doesn't provide accessibility for an `svg` with role `img` for all screen readers

## Changes

- add `aria-label`, `aria-labelledby`, `aria-describedby`, `isPresentational`
- update `FooterCfGov` to use these labels

## How to test this PR

1. Can you add `aria-label`, `aria-labelledby`, `aria-describedby`, `isPresentational` attributes to an Icon's `<svg>` tag?
2. Have these labels been added to the svgs of the cfgov footer?

## Screenshots
![Screenshot 2024-03-29 at 1 24 28 PM](https://github.com/cfpb/design-system-react/assets/19983248/973ea942-a8ed-4888-9263-b79a9f41c410)

Before:
![Screenshot 2024-03-29 at 1 34 44 PM](https://github.com/cfpb/design-system-react/assets/19983248/b138216b-f25d-4b45-9eb4-83920fb7efbc)



After:
![Screenshot 2024-03-29 at 1 35 15 PM](https://github.com/cfpb/design-system-react/assets/19983248/62c8f6a8-b544-4ce1-8001-0dd3dd70e481)

## Notes

- More accessibility fixes to come! 🥳
