### PR TITLE
fix(hero): let headingLevel dictate the heading tag without enclosing <p> tag

### DIFF
--- a/src/components/Hero/Hero.test.tsx
+++ b/src/components/Hero/Hero.test.tsx
@@ -85,7 +85,7 @@ describe('Hero', () => {
     expect(header).toHaveProperty('textContent', headingText);
 
     // Subheading
-    const subheading = screen.getByRole('heading', { level: 3 });
+    const subheading = screen.getByRole('heading', { level: subheadingLevel });
     expect(subheading).toHaveProperty('textContent', subheadingText);
   });
 });

--- a/src/components/Hero/Hero.test.tsx
+++ b/src/components/Hero/Hero.test.tsx
@@ -66,19 +66,26 @@ describe('Hero', () => {
   });
 
   it('Applies heading levels', () => {
-    const headingLevel = 'h4';
-    const subheadingLevel = 'h3';
+    const headingLevel = 2;
+    const headingText = 'Heading text';
+    const subheadingLevel = 3;
+    const subheadingText = 'Subheading text';
 
     render(
-      <Hero headingLevel={headingLevel} subheadingLevel={subheadingLevel} />
+      <Hero
+        heading='Heading text'
+        headingLevel={`h${headingLevel}`}
+        subheading='Subheading text'
+        subheadingLevel={`h${subheadingLevel}`}
+      />
     );
 
     // Heading
-    const heading = screen.getByTestId('hero-heading');
-    expect(heading.className).toMatch(headingLevel);
+    const header = screen.getByRole('heading', { level: headingLevel });
+    expect(header).toHaveProperty('textContent', headingText);
 
     // Subheading
-    const subheading = screen.getByTestId('hero-subheading');
-    expect(subheading.className).toMatch(subheadingLevel);
+    const subheading = screen.getByRole('heading', { level: 3 });
+    expect(subheading).toHaveProperty('textContent', subheadingText);
   });
 });

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -1,6 +1,7 @@
 import classnames from 'classnames';
-import { createElement } from 'react';
 import type { HeadingLevel } from '../../types/headingLevel';
+import type { HeadingType } from '../Headings/Heading';
+import { Heading } from '../Headings/Heading';
 import { HeroImage } from './HeroImage';
 import './hero.less';
 import { useBackgroundImage } from './useBackgroundImage';
@@ -51,25 +52,41 @@ export default function Hero({
   if (isKnockout) heroCnames.push('m-hero__knockout');
   if (imageIsPhoto) heroCnames.push('m-hero__overlay');
 
+  // NOTE: This is a mapping of the Hero component's HeadingLevel to the Heading component's
+  // HeadingType but we could also use the HeadingType directly in the Hero component with some
+  // refactoring of the Heading component or run a regex replace on the HeadingLevel in the Hero
+  const HeadingLevelToHeadingType: Record<string, HeadingType> = {
+    h1: '1',
+    h2: '2',
+    h3: '3',
+    h4: '4',
+    h5: '5',
+    display: 'display',
+    eyebrow: 'eyebrow',
+    slug: 'slug'
+  };
+
   return (
     <div className={classnames(heroCnames)} style={heroStyles} {...properties}>
       <div className='m-hero_wrapper' ref={wrapperReference}>
         <div className='m-hero_text' style={textStyles} data-testid='hero-text'>
-          {createElement(
-            headingLevel,
-            {
-              className: `m-hero_heading ${headingLevel}`,
-              'data-testid': 'hero-heading'
-            },
-            heading
-          )}
-          {createElement(
-            subheadingLevel,
-            {
-              className: `m-hero_subhead ${subheadingLevel}`,
-              'data-testid': 'hero-subheading'
-            },
-            subheading
+          <Heading
+            className='m-hero_heading'
+            data-testid='hero-heading'
+            type={HeadingLevelToHeadingType[headingLevel]}
+          >
+            {heading}
+          </Heading>
+          {subheadingLevel === 'p' ? (
+            <p className='m-hero_subhead'>{subheading}</p>
+          ) : (
+            <Heading
+              className='m-hero_subhead'
+              data-testid='hero-subheading'
+              type={HeadingLevelToHeadingType[subheadingLevel]}
+            >
+              {subheading}
+            </Heading>
           )}
         </div>
         <HeroImage image={image} altText={imageAltText} />

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -1,4 +1,5 @@
 import classnames from 'classnames';
+import { createElement } from 'react';
 import type { HeadingLevel } from '../../types/headingLevel';
 import { HeroImage } from './HeroImage';
 import './hero.less';
@@ -15,7 +16,7 @@ interface HeroProperties extends React.HTMLAttributes<HTMLDivElement> {
   isJumbo?: boolean;
   isKnockout?: boolean;
   subheading?: React.ReactNode;
-  subheadingLevel?: HeadingLevel;
+  subheadingLevel?: HeadingLevel | 'p';
   textColor?: string;
 }
 
@@ -33,7 +34,7 @@ export default function Hero({
   isJumbo,
   isKnockout,
   subheading,
-  subheadingLevel,
+  subheadingLevel = 'p',
   textColor,
   className,
   ...properties
@@ -54,18 +55,22 @@ export default function Hero({
     <div className={classnames(heroCnames)} style={heroStyles} {...properties}>
       <div className='m-hero_wrapper' ref={wrapperReference}>
         <div className='m-hero_text' style={textStyles} data-testid='hero-text'>
-          <p
-            className={`m-hero_heading ${headingLevel}`}
-            data-testid='hero-heading'
-          >
-            {heading}
-          </p>
-          <p
-            className={`m-hero_subhead ${subheadingLevel ?? ''}`}
-            data-testid='hero-subheading'
-          >
-            {subheading}
-          </p>
+          {createElement(
+            headingLevel,
+            {
+              className: `m-hero_heading ${headingLevel}`,
+              'data-testid': 'hero-heading'
+            },
+            heading
+          )}
+          {createElement(
+            subheadingLevel,
+            {
+              className: `m-hero_subhead ${subheadingLevel}`,
+              'data-testid': 'hero-subheading'
+            },
+            subheading
+          )}
         </div>
         <HeroImage image={image} altText={imageAltText} />
       </div>


### PR DESCRIPTION
A little bit of a nuanced issue here that affects accessibility. Right now, if I wanted the heading of a hero to be a `<h1>` instead of a `<p>` tag, I could pass in the full node instead of the text:

Instead of this: 
`heading={My super cool heading!}`
Do this: 
`heading={<h1>My super cool heading!</h1>}`

The problem with that is that then the heading still renders inside of a `<p>` tag, which isn't great, but also the stylings of the heading wouldn't get applied to the heading but instead get applied to the enclosing `<p>` tag.

So this PR instead allows the `headingLevel` to create a heading with the `heading` content directly, instead of being wrapped in a `<p>` tag. This lets you set the `heading` to be an `<h1>` or other heading level a little easier, which we'll want for accessibility and also matches [the markdown of the DS](https://cfpb.github.io/design-system/patterns/heroes#hero-with-illustration) a little better by removing the enclosing `<p>` tag. I've also done something similar for the `subheading` but also it defaults to being a `<p>` tag.

I used `createElement` to do this because it's the easiest to implement with Typescript. There are ways of doing this with maybe cloning the element that gets passed to the `heading` node and then passing it the heading classes... but I think is probably a way that will guide people to creating accessible heroes and it follows the DS in making heroes usually just have the primary headings as `h1`s. 

Closes: #328 

EDIT 4/1: I also am exploring a different way of handling this, by just using the `<Heading>` component directly. Here's [the commit](https://github.com/cfpb/design-system-react/commit/0c2c03788d62b2393e48881e110331b782dc560f) on an experimental branch, so please take a peek at that too @meissadia and let me know which you prefer. 👍

## Changes

- uses `headingLevel` and `heading` to create headings using `createElement`, instead of elements inside `<p>` tags
- does it similarly for `subheadingLevel` and `subheading`, but also allows `<p>`

## How to test this PR

1. Do `Hero`s now render the heading and subheading with the element dictated by the `headingLevel`?

## Screenshots
_Before when trying to make a hero heading an `h1` by passing in `<h1>Test</h1>` or `<Heading>` into `heading` (style is incorrect and wrapped in `<p>`_
<img width="904" alt="Screenshot 2024-03-31 at 3 56 30 PM" src="https://github.com/cfpb/design-system-react/assets/19983248/ddaeb4e9-2672-46c4-a2b9-77fa94abcf78">

_Before when trying to make a hero heading by just passing in the heading as `"Test"` (renders with p tag)_
<img width="878" alt="Screenshot 2024-03-31 at 3 58 23 PM" src="https://github.com/cfpb/design-system-react/assets/19983248/0002ece5-ffc2-484d-80a3-95e4e4909b38">

_After PR with passing `"Test"` as `heading`_
<img width="861" alt="Screenshot 2024-03-31 at 3 55 36 PM" src="https://github.com/cfpb/design-system-react/assets/19983248/01c14360-82a2-4cb4-8373-0fc67b7f7a3e">
