### PR TITLE
fix(skip-link): add focus ring

### DIFF
--- a/src/components/SkipNav/SkipNav.less
+++ b/src/components/SkipNav/SkipNav.less
@@ -28,6 +28,8 @@
       overflow: visible;
       outline: 0;
       transition: transform 0.1s ease, background 0.2s linear;
+      outline: 1px dotted @pacific;
+      outline-offset: 1px;
     }
 
     &__flush-left:focus {


### PR DESCRIPTION
A very small change to add the focus ring in for skip links like it appears on consumerfinance.gov. There are other styles we could add from there potentially in the future, but the focus ring is the one that matter for accessibility, so I would like to prioritize this small change first.

## Changes

- adds in focus ring as per consumerfinance.gov 's example

## How to test this PR

1. Does this add a focus ring to the skip link?

## Screenshots
_Before_
<img width="377" alt="Screenshot 2024-04-02 at 3 36 59 AM" src="https://github.com/cfpb/design-system-react/assets/19983248/08024167-2f4a-4682-a4ae-a4d76f969796">

_After_
<img width="533" alt="Screenshot 2024-04-02 at 3 35 55 AM" src="https://github.com/cfpb/design-system-react/assets/19983248/d59a8604-db63-45de-b87b-f5e579386d65">

_Example from consumerfinance.gov_
<img width="348" alt="Screenshot 2024-04-02 at 3 36 19 AM" src="https://github.com/cfpb/design-system-react/assets/19983248/e9f88007-5e79-481b-a293-337a417a8850">


## Notes
- we can enhance this component's styling more in the future with the fancier transition from consumerfinance.gov, etc. but for now let's get the necessary accessible parts in ASAP
