### PR TITLE
fix(page-header): change html to semantic header instead of div

### DIFF
--- a/src/components/PageHeader/PageHeader.tsx
+++ b/src/components/PageHeader/PageHeader.tsx
@@ -13,9 +13,9 @@ export default function PageHeader({
   user
 }: PageHeaderProperties): JSX.Element {
   return (
-    <div className='o-header'>
+    <header className='o-header'>
       <Banner tagline='An official website of the United States government' />
       <Navbar {...{ links, user }} />
-    </div>
+    </header>
   );
 }


### PR DESCRIPTION
Small change to make the header be wrapped in a semantic tag of `header` instead of a `div` for accessibility

## Changes

- change `div` to `header`
