### PR TITLE
Create Declarable CFPB Logo href

### DIFF
--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -7,11 +7,13 @@ interface CfpbLogoProperties {
   href?: string;
 }
 
-export function CfpbLogo({ href }: CfpbLogoProperties): JSX.Element {
+export function CfpbLogo({
+  href = 'https://www.consumerfinance.gov'
+}: CfpbLogoProperties): JSX.Element {
   return (
     <Link
       data-testid='CfpbLogoLink'
-      href={href ?? 'https://www.consumerfinance.gov'}
+      href={href}
       title='Home'
       aria-label='Home'
       className='o-header_logo'

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -3,10 +3,15 @@ import CFPBLogo from '../../assets/images/cfpb-logo.png';
 import Link from '../Link/Link';
 import './navbar.less';
 
-export function CfpbLogo(): JSX.Element {
+interface CfpbLogoProperties {
+  href?: string;
+}
+
+export function CfpbLogo({ href }: CfpbLogoProperties): JSX.Element {
   return (
     <Link
-      href='https://www.consumerfinance.gov/'
+      data-testid='CfpbLogoLink'
+      href={href ?? 'https://www.consumerfinance.gov'}
       title='Home'
       aria-label='Home'
       className='o-header_logo'
@@ -29,6 +34,7 @@ const Links = ({
 interface NavbarProperties {
   links?: JSX.Element[];
   user?: User;
+  href?: string;
 }
 
 export interface User {
@@ -63,11 +69,15 @@ const UserActions = ({ user }: UserActionsProperties): JSXElement => {
   );
 };
 
-export default function Navbar({ links, user }: NavbarProperties): JSX.Element {
+export default function Navbar({
+  links,
+  user,
+  href
+}: NavbarProperties): JSX.Element {
   return (
     <div className='o-header_content'>
       <div className='navbar wrapper wrapper__match-content'>
-        <CfpbLogo />
+        <CfpbLogo href={href} />
         <div className='nav-items'>
           <Links elements={links} />
           <UserActions user={user} />

--- a/src/components/PageHeader/PageHeader.test.tsx
+++ b/src/components/PageHeader/PageHeader.test.tsx
@@ -1,0 +1,21 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import PageHeader from './PageHeader';
+
+describe('PageHeader', () => {
+  it('Logo href should have custom declared value', () => {
+    render(<PageHeader href='https://www.google.com' />);
+    expect(screen.getByTestId('CfpbLogoLink')).toHaveAttribute(
+      'href',
+      'https://www.google.com'
+    );
+  });
+
+  it('Logo with undeclared href should default to cf.govq', () => {
+    render(<PageHeader />);
+    expect(screen.getByTestId('CfpbLogoLink')).toHaveAttribute(
+      'href',
+      'https://www.consumerfinance.gov'
+    );
+  });
+});

--- a/src/components/PageHeader/PageHeader.tsx
+++ b/src/components/PageHeader/PageHeader.tsx
@@ -6,16 +6,18 @@ import './header.less';
 interface PageHeaderProperties {
   links?: JSX.Element[];
   user?: User;
+  href?: string;
 }
 
 export default function PageHeader({
   links,
-  user
+  user,
+  href
 }: PageHeaderProperties): JSX.Element {
   return (
     <header className='o-header'>
       <Banner tagline='An official website of the United States government' />
-      <Navbar {...{ links, user }} />
+      <Navbar {...{ links, user, href }} />
     </header>
   );
 }


### PR DESCRIPTION
## Description

Currently, the CFPB logo in the React DS has a hardcoded href pointing to cf.gov. Using the CFPB logo from the React DS, we've run into the issue of users being booted from the Metro2 tool when the logo is clicked. This will inevitably cause frustration and confusion, as users will expect to be routed back to the landing page for the Metro2 Evaluator Tool. 

This PR seeks to implement a change which will turn the logo href into a prop that can be defined in every project that uses the React DS component. Additionally, the logo still defaults to cf.gov if no other href/url is specified. 

## Changes

- href prop created for CfpbLogo, passed to Navbar and PageHeader
- test file created for page header to include testing custom href and/or defaulting to cf.gov

## How to test this PR

1. Pull branch and run `yarn start`. Navigate to [Navbar](http://localhost:6006/?path=/docs/components-draft-navbar--overview) and [Page header](http://localhost:6006/?path=/docs/components-draft-page-header--overview) pages and verify CFPB logo points to cf.gov

2. Create a story for either Navbar or PageHeader:
- Open file 'PageHeader.stories.tsx'
- Create an additional story that displays the CFPB logo with custom href `export const CustomCFPBHref: Story = {  args: { href: 'https://www.google.com'  } };`
- Go to [PageHeader](http://localhost:6006/?path=/docs/components-draft-page-header--overview) page in React DS and verify additional story was created. Click added CFPB logo (or hover above logo/link) and verify correct url  

3. Check added test with `yarn test` and verify tests pass

## Notes

- Following the guidelines for adding unit tests, a PageHeader.test.tsx file was created. 