### PR TITLE
[RadioButton] Accept additional input props

### DIFF
--- a/src/components/RadioButton/RadioButton.test.tsx
+++ b/src/components/RadioButton/RadioButton.test.tsx
@@ -49,6 +49,16 @@ describe('<RadioButton />', () => {
     expect(element.getAttribute('disabled')).toBe('');
   });
 
+  it('accepts additional input element props', () => {
+    const properties = buildProperties('default-checked');
+    render(<RadioButton {...properties} defaultChecked />);
+
+    const element = screen.getByRole(role);
+
+    expect(element).toBeInTheDocument();
+    expect(element).toBeChecked();
+  });
+
   it('Select via click', () => {
     const properties = buildProperties('click');
     render(<RadioButton {...properties} />);

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -33,7 +33,8 @@ export const RadioButton = ({
   labelClassName,
   labelInline = true, // 'true' REMOVES the a.label__heading class
   label,
-  inputRef
+  inputRef,
+  ...properties
 }: JSX.IntrinsicElements['input'] & RadioProperties): React.ReactElement => {
   const classes = [...baseStyles, className].join(' ');
   const containerClasses = [
@@ -50,6 +51,7 @@ export const RadioButton = ({
         className={classes}
         ref={inputRef}
         disabled={disabled}
+        {...properties}
       />
       <Label htmlFor={id} className={labelClassName} inline={labelInline}>
         {label}


### PR DESCRIPTION
It isn't currently possible to set properties on the RadioButton input that aren’t specifically enumerated in the the component’s props. This PR addresses that by passing any remaining props to the input element.

## Changes
- Pass extra props to RadioButton input element
- Test for adding a defaultChecked prop to RadioButton 

## How to test this PR

1. Verify that tests pass

