### PR TITLE
feat: [PageHeader] Enable/disable bottom border

### DIFF
--- a/src/components/PageHeader/PageHeader.test.tsx
+++ b/src/components/PageHeader/PageHeader.test.tsx
@@ -18,4 +18,14 @@ describe('PageHeader', () => {
       'https://www.consumerfinance.gov'
     );
   });
+
+  it('Renders with bottom border by default', () => {
+    const { container } = render(<PageHeader />);
+    expect(container.firstChild.className).toBe('o-header bottom-border');
+  });
+
+  it('Can be rendered without bottom border', () => {
+    const { container } = render(<PageHeader withBottomBorder={false} />);
+    expect(container.firstChild.className).toBe('o-header');
+  });
 });

--- a/src/components/PageHeader/PageHeader.tsx
+++ b/src/components/PageHeader/PageHeader.tsx
@@ -1,3 +1,4 @@
+import classnames from 'classnames';
 import { Banner } from '../Banner/Banner';
 import type { User } from '../Navbar/Navbar';
 import Navbar from '../Navbar/Navbar';
@@ -7,15 +8,20 @@ interface PageHeaderProperties {
   links?: JSX.Element[];
   user?: User;
   href?: string;
+  withBottomBorder?: boolean;
 }
 
 export default function PageHeader({
   links,
   user,
-  href
+  href,
+  withBottomBorder = true
 }: PageHeaderProperties): JSX.Element {
+  const headerClasses = ['o-header'];
+  if (withBottomBorder) headerClasses.push('bottom-border');
+
   return (
-    <header className='o-header'>
+    <header className={classnames(headerClasses)}>
       <Banner tagline='An official website of the United States government' />
       <Navbar {...{ links, user, href }} />
     </header>

--- a/src/components/PageHeader/header.less
+++ b/src/components/PageHeader/header.less
@@ -1,10 +1,14 @@
 .o-header {
   min-width: 320px;
-  border-bottom: 5px solid #20aa3f;
   position: relative;
   z-index: 10;
   background-color: #ffffff;
+  
+  &.bottom-border {
+    border-bottom: 5px solid #20aa3f;
+  }
 }
+
 @media only all and (min-width: 63.8125em) {
   .o-header {
     min-width: 1021px;


### PR DESCRIPTION
In support of https://github.com/cfpb/sbl-frontend/issues/514

## Changes

- Enable the removal of the bottom border via prop
- Add unit test

## How to test this PR

1. yarn test PageHeader

## Screenshots
### With Border
![screencapture-localhost-6006-2024-05-21-11_09_13](https://github.com/cfpb/design-system-react/assets/2592907/68ffb80e-1c0f-40a3-97a3-ed487504d508)

### Without border
![screencapture-localhost-6006-2024-05-21-11_09_30](https://github.com/cfpb/design-system-react/assets/2592907/e8b12ab3-ccb9-4c95-8b66-6481e0e45fd7)


