### PR TITLE
fix(typescript): remove old ReactNode types

### DIFF
--- a/src/components/Headings/Heading.tsx
+++ b/src/components/Headings/Heading.tsx
@@ -1,5 +1,4 @@
 import classnames from 'classnames';
-import type { ReactNode } from 'react';
 
 export type HeadingType =
   | '1'
@@ -21,7 +20,7 @@ export const Heading = ({
   children,
   className,
   ...properties
-}: HeadingProperties): ReactNode => {
+}: HeadingProperties): JSX.Element => {
   let DynamicHeading: keyof JSX.IntrinsicElements;
   const classes = [className];
 

--- a/src/components/Paragraph/Paragraph.tsx
+++ b/src/components/Paragraph/Paragraph.tsx
@@ -1,5 +1,4 @@
 import classnames from 'classnames';
-import type { ReactNode } from 'react';
 
 interface ParagraphProperties extends React.HTMLProps<HTMLParagraphElement> {
   isLead?: boolean;
@@ -15,7 +14,7 @@ export function Paragraph({
   isLead,
   className,
   ...properties
-}: ParagraphProperties): ReactNode {
+}: ParagraphProperties): JSX.Element {
   const cnames = [className];
 
   if (isLead) cnames.push('lead-paragraph');


### PR DESCRIPTION
The oldest components in the library appear to be using ReactNode instead of JSX.Element. This should fix some of the weird linting errors in repos that use the DSR

## Changes

- changes ReactNode to JSX.Element for paragraph and headings

## How to test this PR

1. Linting errors should go away when these components are used.

## Screenshots

<img width="744" alt="Screenshot 2024-05-24 at 8 50 50 AM" src="https://github.com/cfpb/design-system-react/assets/19983248/54e4b387-259c-4897-bf1b-4442a8a93dce">
