### PR TITLE
fix: [Table] Pagination input label's 'for' property  needs to align with the input id

### DIFF
--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import type { EventHandler, ReactElement, SyntheticEvent } from 'react';
-import { useEffect, useState } from 'react';
+import { useEffect, useId, useState } from 'react';
 import { noOp } from '../../utils/noOp';
 import { Icon } from '../Icon/Icon';
 import { Label } from '../Label/Label';
@@ -9,7 +9,7 @@ import { MIN_PAGE } from './paginationConstants';
 
 export interface PaginationProperties {
   /** Identifier of the table this element controls */
-  tableId: string;
+  tableId?: string;
   /** Currently displayed page number  */
   page: number;
   /** Total number of available pages */
@@ -146,6 +146,8 @@ export const Pagination = ({
     onClickGo(targetPage);
   };
 
+  const paginationId = useId();
+
   const onInputChange = setPageNumber;
 
   return (
@@ -171,7 +173,7 @@ export const Pagination = ({
         onSubmit={onSubmit}
       >
         <PaginationInput
-          tableId={tableId}
+          tableId={tableId ?? paginationId}
           page={pageNumber}
           pageCount={pageCount}
           onChange={onInputChange}

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -8,6 +8,8 @@ import './pagination.less';
 import { MIN_PAGE } from './paginationConstants';
 
 export interface PaginationProperties {
+  /** Identifier of the table this element controls */
+  tableId: string;
   /** Currently displayed page number  */
   page: number;
   /** Total number of available pages */
@@ -79,12 +81,14 @@ const PaginationNavButton = ({
 };
 
 interface PaginationInputProperties {
+  tableId: string;
   page: number;
   pageCount: number;
   onChange: (value: number) => void;
 }
 
 const PaginationInput = ({
+  tableId,
   page,
   pageCount,
   onChange
@@ -93,17 +97,15 @@ const PaginationInput = ({
     onChange(Number.parseInt(event.currentTarget.value, 10));
   };
 
+  const inputId = `${tableId}-pagination_current-page`;
+
   return (
-    <Label
-      className='m-pagination_label'
-      htmlFor='pagination_current-page'
-      inline
-    >
+    <Label className='m-pagination_label' htmlFor={inputId} inline>
       Page
       <span className='u-visually-hidden'>number {page} out</span>
       <input
         className='m-pagination_current-page'
-        id='pagination_current-page'
+        id={inputId}
         name='page'
         type='number'
         min='1'
@@ -124,6 +126,7 @@ const PaginationInput = ({
  * Source: https://cfpb.github.io/design-system/components/pagination
  */
 export const Pagination = ({
+  tableId,
   page,
   pageCount,
   onClickPrevious = noOp,
@@ -168,6 +171,7 @@ export const Pagination = ({
         onSubmit={onSubmit}
       >
         <PaginationInput
+          tableId={tableId}
           page={pageNumber}
           pageCount={pageCount}
           onChange={onInputChange}

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -96,14 +96,14 @@ const PaginationInput = ({
   return (
     <Label
       className='m-pagination_label'
-      htmlFor='m-pagination_current-page'
+      htmlFor='pagination_current-page'
       inline
     >
       Page
       <span className='u-visually-hidden'>number {page} out</span>
       <input
         className='m-pagination_current-page'
-        id='m-pagination_current-page-default'
+        id='pagination_current-page'
         name='page'
         type='number'
         min='1'

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -25,6 +25,8 @@ export interface TableColumnConfiguration {
 export type TableColumn = TableColumnConfiguration | string;
 
 export interface TableProperties {
+  // Unique identifier
+  id: string;
   // Table description, displayed atop the table
   caption?: ReactNode;
   // Array of column headers or column configurations
@@ -55,6 +57,7 @@ export interface TableProperties {
  * Source: https://cfpb.github.io/design-system/components/tables
  */
 export const Table = ({
+  id,
   caption,
   columns,
   rows,
@@ -95,7 +98,9 @@ export const Table = ({
         {buildColumnHeaders(columns)}
         {buildRows(visibleRows, columns)}
       </table>
-      {isPaginated ? <Pagination {...paginationProperties} /> : null}
+      {isPaginated ? (
+        <Pagination {...paginationProperties} tableId={id} />
+      ) : null}
     </>
   );
 

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { type ReactNode } from 'react';
+import { useId, type ReactNode } from 'react';
 import type { JSXElement } from '~/src/types/jsxElement';
 import { type WidthPercent } from '../../types/WidthPercent';
 import { Pagination } from '../Pagination/Pagination';
@@ -26,7 +26,7 @@ export type TableColumn = TableColumnConfiguration | string;
 
 export interface TableProperties {
   // Unique identifier
-  id: string;
+  id?: string;
   // Table description, displayed atop the table
   caption?: ReactNode;
   // Array of column headers or column configurations
@@ -78,6 +78,8 @@ export const Table = ({
     perPage
   });
 
+  const tableId = useId();
+
   const tableClassnames = [];
 
   if (isResponsive || isDirectory)
@@ -92,6 +94,7 @@ export const Table = ({
       <table
         data-testid='table-testid'
         className={classNames(tableClassnames)}
+        id={id ?? tableId}
         {...others}
       >
         <Caption>{caption}</Caption>
@@ -99,7 +102,7 @@ export const Table = ({
         {buildRows(visibleRows, columns)}
       </table>
       {isPaginated ? (
-        <Pagination {...paginationProperties} tableId={id} />
+        <Pagination {...paginationProperties} tableId={id ?? tableId} />
       ) : null}
     </>
   );


### PR DESCRIPTION
Accessibility improvement

## Changes
- [Table] Propagate Table id to Pagination component
- [Pagination] Utilize `tableId` to uniquely identify and label Pagination's input element

## How to test this PR

1. Load paginated table in an application (couldn't get ANDI to recognize the error in Storybook)
2. Run [ANDI](https://www.ssa.gov/accessibility/andi/help/install.html) accessibility tool
3. Verify that it doesn't identify the following error
    - `Element nested in <label> but label[for=m-pagination_current-page] does not match element [id=m-pagination_current-page-default`

## Screenshots
|ANDI Before|ANDI After|
|---|---|
|![Screenshot 2024-05-24 at 3 32 30 PM](https://github.com/cfpb/design-system-react/assets/2592907/cab51fd4-d9ae-467f-be96-78fcb006d434)|![Screenshot 2024-05-24 at 3 29 22 PM](https://github.com/cfpb/design-system-react/assets/2592907/ef31e63c-fa18-472f-ade8-8337965bcf4b)|

