### PR TITLE
Updated OIG footer link address

### DIFF
--- a/src/components/Footer/FooterCfGov.tsx
+++ b/src/components/Footer/FooterCfGov.tsx
@@ -150,7 +150,7 @@ export const FooterCfGov = ({
     <a
       key='inspector'
       className='a-link a-link__icon'
-      href='https://www.federalreserve.gov/oig/default.htm'
+      href='https://oig.federalreserve.gov/'
     >
       <span className='a-link_text'>Office of Inspector General</span>
       <Icon


### PR DESCRIPTION
Updated link address to https://oig.federalreserve.gov/