### PR TITLE
[TextInput] Certain props should be optional

### DIFF
--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -30,7 +30,6 @@ interface CustomTextInputProperties extends ComponentPropsWithoutRef<'input'> {
   isFullWidth?: boolean;
 }
 
-// export type OptionalTextInputProperties = CustomTextInputProperties & JSX.IntrinsicElements['input'];
 export type OptionalTextInputProperties = CustomTextInputProperties;
 
 export type TextInputProperties = OptionalTextInputProperties &

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import type { ComponentPropsWithoutRef, Ref } from 'react';
+import type { ComponentPropsWithoutRef } from 'react';
 import { forwardRef, type ReactNode } from 'react';
 import type { TextInputStatusType } from './TextInputStatus';
 import { getTextInputStatusClass } from './TextInputStatus';

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -33,7 +33,8 @@ interface CustomTextInputProperties extends ComponentPropsWithoutRef<'input'> {
 // export type OptionalTextInputProperties = CustomTextInputProperties & JSX.IntrinsicElements['input'];
 export type OptionalTextInputProperties = CustomTextInputProperties;
 
-export type TextInputProperties = OptionalTextInputProperties & RequiredTextInputProperties;
+export type TextInputProperties = OptionalTextInputProperties &
+  RequiredTextInputProperties;
 
 /**
  * Source: <a href='https://cfpb.github.io/design-system/components/text-inputs' target='_blank'> https://cfpb.github.io/design-system/components/text-inputs</a>

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import type { Ref } from 'react';
+import type { ComponentPropsWithoutRef, Ref } from 'react';
 import { forwardRef, type ReactNode } from 'react';
 import type { TextInputStatusType } from './TextInputStatus';
 import { getTextInputStatusClass } from './TextInputStatus';
@@ -20,7 +20,7 @@ interface RequiredTextInputProperties {
   name: string;
 }
 
-interface CustomTextInputProperties {
+interface CustomTextInputProperties extends ComponentPropsWithoutRef<'input'> {
   className?: string;
   inputProps?: JSX.IntrinsicElements['input'];
   inputRef?: TextInputReference;
@@ -30,16 +30,15 @@ interface CustomTextInputProperties {
   isFullWidth?: boolean;
 }
 
-export type OptionalTextInputProperties = CustomTextInputProperties &
-  JSX.IntrinsicElements['input'];
+// export type OptionalTextInputProperties = CustomTextInputProperties & JSX.IntrinsicElements['input'];
+export type OptionalTextInputProperties = CustomTextInputProperties;
 
-export type TextInputProperties = OptionalTextInputProperties &
-  RequiredTextInputProperties;
+export type TextInputProperties = OptionalTextInputProperties & RequiredTextInputProperties;
 
 /**
  * Source: <a href='https://cfpb.github.io/design-system/components/text-inputs' target='_blank'> https://cfpb.github.io/design-system/components/text-inputs</a>
  */
-export const TextInput = forwardRef(
+export const TextInput = forwardRef<HTMLInputElement, TextInputProperties>(
   (
     {
       className,
@@ -49,10 +48,11 @@ export const TextInput = forwardRef(
       name,
       status = 'info',
       type = 'text',
+      maxLength,
       isFullWidth = false,
       ...otherInputProperties
-    }: JSX.IntrinsicElements['input'] & TextInputProperties,
-    reference: Ref<HTMLInputElement>
+    },
+    reference
   ) => {
     const classes = [
       'a-text-input',

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -48,7 +48,6 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProperties>(
       name,
       status = 'info',
       type = 'text',
-      maxLength,
       isFullWidth = false,
       ...otherInputProperties
     },


### PR DESCRIPTION
[Short description explaining the high-level reason for the pull request]

## Changes

- TextInput.tsx: Updated the property typing to fix an issue which caused properties that should be optional, to be considered mandatory instead.

## How to test this PR

1. View and verify the the deploy preview
2. Pull **308-ts-error-fix**
3. Run **yarn lint** against the branch
4. Verify that **TextInput.tsx** has no errors
5. Run **yarn test** against the branch and verify that everything passes
6. Build the package
7. Update the **package.json** in **sbl-frontend** to include **"design-system-react": "file:./<path-to-package.tgz>/package.tgz"**
8. Run **yarn install**
9. Pull **986-default-max-length** in **sbl-frontend**
10. Verify that **TextInput.tsx** in **sbl-frontend** has no errors