### PR TITLE
fix: [Expandable] Correct icon color

### DIFF
--- a/src/components/Expandable/Expandable.tsx
+++ b/src/components/Expandable/Expandable.tsx
@@ -50,7 +50,7 @@ export const Expandable: React.FC<ExpandableProperties> = ({
         title={header}
       >
         <h3 className='h4 o-expandable_label'>{header}</h3>
-        <span className='o-expandable_link'>
+        <span className='o-expandable_cues'>
           <span className='o-expandable_cue o-expandable_cue-open'>
             <Icon name='plus-round' alt='plus-round' />
           </span>


### PR DESCRIPTION
Closes #385

## Changes

- Match structure of DS Expandable component to allow the existing CSS styles to be correctly applied to the DSR Expandable

## How to test this PR

1. Compare screenshots

## Screenshots

### Before
<img width="1028" alt="Screenshot 2025-01-10 at 11 23 29 AM" src="https://github.com/user-attachments/assets/c057e4a9-cc04-446f-8f73-27fe48c83eb3" />

### After 
<img width="1022" alt="Screenshot 2025-01-10 at 11 22 56 AM" src="https://github.com/user-attachments/assets/1b2b3730-0ce7-4558-babb-8c818cf354e4" />

### [DSR Expandable](https://cfpb.github.io/design-system/components/expandables)
<img width="831" alt="Screenshot 2025-01-10 at 12 37 01 PM" src="https://github.com/user-attachments/assets/ea24a264-27f9-464a-9f65-31c7820da60d" />
<img width="830" alt="Screenshot 2025-01-10 at 12 37 17 PM" src="https://github.com/user-attachments/assets/857285bd-88e7-4914-9261-b3d3fd13599d" />

