### PR TITLE
spike(deploy): test out deployment on known good commit

### DIFF
--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -15,7 +15,7 @@ type Story = StoryObj<typeof meta>;
 export const Standard: Story = {
   name: 'Standard table',
   args: {
-    caption: 'Table caption describing the data',
+    caption: 'Table caption describing the data TEST',
     columns: ['Column 1 header', 'Column 2 header', 'Column 3 header'],
     rows: [
       ['Row 1, Column 1', 'Row 1, Column 2', 'Row 1, Column 3'],


### PR DESCRIPTION
# DRAFT TEST OF DEPLOYS

Currently when there's no message but has children (explanations), then a `m-notification_explanation` applied which makes it not possible to achieve designs like these (unbolded, aligned text):

<img width="1143" alt="Screenshot 2024-11-19 at 4 13 26 PM" src="https://github.com/user-attachments/assets/e78ff4a4-6c08-4df8-9455-4e6648a57701">

<img width="648" alt="Screenshot 2024-11-19 at 4 16 46 PM" src="https://github.com/user-attachments/assets/6f053344-afef-4b12-a8fe-4efcf264cc8c">


## Changes

- if there is no message, but still has children then do not apply `m-notification_explanation` to allow alert flexibility

## How to test this PR

1. Do the tests pass?
2. How do the examples look?
3. Try modifying the package.json to point the DSR to this commit and see how the alerts are affected.

## Screenshots
<img width="1346" alt="Screenshot 2024-11-19 at 4 21 12 PM" src="https://github.com/user-attachments/assets/add6b874-260f-4e77-b6a8-6ddbeb5ecfbb">

