### PR TITLE
Update readme path to example button test file 

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Note: This project uses yarn v3.5 in "plug n play" mode. There is no `node_modul
 
 Edit the files in `src/components/` and your browser should hot reload your changes.
 
-Add tests to files called `<component-name>.test.tsx`. See [`Buttons.test.tsx`](/src/components/Button.test.tsx) for an example.
+Add tests to files called `<component-name>.test.tsx`. See [`Buttons.test.tsx`](/src/components/Buttons/Button.test.tsx) for an example.
 
 Run `yarn test` to watch for changes and run tests automatically.
 


### PR DESCRIPTION
Update path to example test in readme.  The existing path is missing the Buttons directory name causing a 404 error. 

## Changes

- Added correct test path to readme

## How to test this PR

1. Run per usual
2. Click on the Buttons.test.tsx link and view the test file

## Screenshots

before
<img width="881" height="440" alt="Screenshot 2026-01-07 at 6 39 40 AM" src="https://github.com/user-attachments/assets/041e1f0e-d13e-4ad3-bf71-9c03ecb21a9e" />

after
<img width="1095" height="511" alt="Screenshot 2026-01-07 at 6 40 04 AM" src="https://github.com/user-attachments/assets/6cc57c87-133e-4a88-b135-f235cb24f06b" />


## Notes

-
