### PR TITLE
Update Expandable.stories.tsx

### DIFF
--- a/src/components/Expandable/Expandable.stories.tsx
+++ b/src/components/Expandable/Expandable.stories.tsx
@@ -66,6 +66,24 @@ export const Default: Story = {
   }
 };
 
+export const PaddedExpandable: Story = {
+  name: 'Padded',
+  args: {
+    ...Default.args,
+    header: 'Expandable label',
+    isPadded: true
+  }
+};
+
+export const OpenOnLoad: Story = {
+   name: 'Open on load',
+   args: {
+    ...Default.args,
+    header: 'Expandable label',
+    openOnLoad: true
+  }
+};
+
 export const DefaultExpandableGroup: Story = {
   name: 'Group',
   render: arguments_ => (
@@ -125,22 +143,7 @@ export const Accordion: Story = {
   }
 };
 
-export const OpenOnLoad: Story = {
-   name: 'Open on load',
-   args: {
-    ...Default.args,
-    header: 'Expandable label',
-    openOnLoad: true
-  }
-};
 
-export const PaddedExpandable: Story = {
-  name: 'Padded',
-  args: {
-    ...Default.args,
-    header: 'Expandable label',
-    isPadded: true
-  }
-};
+
 
 


### PR DESCRIPTION
This PR changes the ordering of the types to match what is currently shown on the CFPB Design System expandables component page. Ultimately, we do plan to make changes to the ordering and expandable types at the CFPB Design System level but I've decided to wait on DSR changes until those DS changes are made. 

## Changes
- Changes ordering of the stories to match the ordering in the CFPB Design System - Expandables component page - https://cfpb.github.io/design-system/components/expandables

## How to test this PR
1. View preview - https://cfpb.github.io/design-system-react/pr-previews/pr-447/?path=/docs/components-draft-expandables--overview 

## Screenshots
| Design System | Design System in React | 
|------------|------------| 
|<img width="4922" height="6728" alt="screencapture-cfpb-github-io-design-system-components-expandables-2026-01-20-15_09_25" src="https://github.com/user-attachments/assets/8189d11b-b153-4607-9ec8-1bd481150b23" />|<img width="886" height="1138" alt="Screenshot 2026-01-20 at 3 12 48 PM" src="https://github.com/user-attachments/assets/569b0304-2ea7-46ee-884c-ceb904116c6c" />|


## Notes
-
