### PR TITLE
update test coverage for expandables and button

### DIFF
--- a/src/components/Buttons/Button.test.tsx
+++ b/src/components/Buttons/Button.test.tsx
@@ -40,6 +40,22 @@ describe('<Button />', () => {
     expect(screen.getByText(wowLabel).textContent).toEqual(wowLabel);
   });
 
+  it('Renders left icon correctly', async () => {
+    render(<Button label={testLabel} iconLeft='left' />);
+    expect(screen.getByText(testLabel)).toBeInTheDocument();
+    expect(screen.getByText(testLabel).textContent).toEqual(testLabel);
+    expect(screen.getByText(testLabel, { selector: 'span' })).toBeInTheDocument();
+    expect(await screen.findByTestId('button-icon-left')).toBeInTheDocument();
+  });
+
+  it('Renders right icon correctly', async () => {
+    render(<Button label={testLabel} iconRight='right' />);
+    expect(screen.getByText(testLabel)).toBeInTheDocument();
+    expect(screen.getByText(testLabel).textContent).toEqual(testLabel);
+    expect(screen.getByText(testLabel, { selector: 'span' })).toBeInTheDocument();
+    expect(await screen.findByTestId('button-icon-right')).toBeInTheDocument();
+  });
+
   it('Renders alternative appearances', () => {
     render(<Button label={testLabel} />);
     expect(screen.getByText(testLabel)).toHaveClass(buttonBaseClass);

--- a/src/components/Buttons/Button.tsx
+++ b/src/components/Buttons/Button.tsx
@@ -78,9 +78,21 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProperties>(
         className={[...styles].join(' ')}
         {...properties}
       >
-        {iconLeft ? <Icon name={iconLeft} isPresentational /> : null}
+        {iconLeft ? (
+          <Icon
+            name={iconLeft}
+            isPresentational
+            data-testid="button-icon-left"
+          />
+        ) : null}
         {iconLeft || iconRight ? <span>{label}</span> : label}
-        {iconRight ? <Icon name={iconRight} isPresentational /> : null}
+        {iconRight ? (
+          <Icon
+            name={iconRight}
+            isPresentational
+            data-testid="button-icon-right"
+          />
+        ) : null}
       </button>
     );
   },

--- a/src/components/Expandable/Expandable.test.tsx
+++ b/src/components/Expandable/Expandable.test.tsx
@@ -1,12 +1,19 @@
 import '@testing-library/jest-dom';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { Expandable as CFPB_Expandable } from '@cfpb/cfpb-design-system/src/components/cfpb-expandables';
 import { Expandable } from './Expandable';
 
 const header = 'Tuesday Rememberance';
 const children = 'It was a warm Spring morning in the midwest...';
 
 describe('<Expandable />', () => {
+  let initSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    initSpy = vi.spyOn(CFPB_Expandable, 'init');
+  });
+
   it('Default', async () => {
     render(<Expandable header={header}>{children}</Expandable>);
 
@@ -18,6 +25,57 @@ describe('<Expandable />', () => {
 
     const content = screen.getByText(children);
     expect(content).toBeInTheDocument();
+  });
+
+  it('Initializes when not in an accordion', () => {
+    render(<Expandable header={header}>{children}</Expandable>);
+    expect(initSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('Does not initialize when in an accordion', () => {
+    render(
+      <Expandable header={header} inAccordion>
+        {children}
+      </Expandable>
+    );
+    expect(initSpy).not.toHaveBeenCalled();
+  });
+
+  it('Adds default standalone styles when not in an accordion', () => {
+    render(<Expandable header={header}>{children}</Expandable>);
+    const expandable = screen.getByTestId('expandable');
+    expect(expandable).toHaveClass('o-expandable--background');
+    expect(expandable).toHaveClass('o-expandable--border');
+  });
+
+  it('Omits default standalone styles when in an accordion', () => {
+    render(
+      <Expandable header={header} inAccordion>
+        {children}
+      </Expandable>
+    );
+    const expandable = screen.getByTestId('expandable');
+    expect(expandable).not.toHaveClass('o-expandable--background');
+    expect(expandable).not.toHaveClass('o-expandable--border');
+  });
+
+  it('Supports padded content', () => {
+    render(
+      <Expandable header={header} isPadded>
+        {children}
+      </Expandable>
+    );
+    const expandable = screen.getByTestId('expandable');
+    expect(expandable).toHaveClass('o-expandable--padded');
+  });
+
+  it('Renders a custom icon when provided', async () => {
+    render(
+      <Expandable header={header} icon='left'>
+        {children}
+      </Expandable>
+    );
+    expect(await screen.findByRole('img', { name: 'left' })).toBeInTheDocument();
   });
 
   it('Supports openOnLoad', async () => {

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,3 +1,4 @@
+import type { SVGProps } from 'react';
 import classNames from 'classnames';
 import { useIconSvg } from '../../hooks/useIconSvg';
 import { numberIcons } from './iconLists';
@@ -49,7 +50,7 @@ const getShapeModifier = (name: string, withBg: boolean): string => {
   return '-round';
 };
 
-interface IconProperties {
+interface IconProperties extends Omit<SVGProps<SVGSVGElement>, 'name'> {
   name: string;
   alt?: string;
   ariaLabel?: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 import { resolve } from 'node:path';
 import processIcons from './postcss/processIcons';
 
+import type { Plugin } from 'vite';
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 import VitePluginReactRemoveAttributes from 'vite-plugin-react-remove-attributes';
@@ -11,24 +12,8 @@ import tsConfigPaths from 'vite-tsconfig-paths';
 import { name } from './package.json';
 import fs from 'fs';
 
-export default defineConfig(() => ({
-  publicDir: false,
-  resolve: {
-    alias: {
-      '~': resolve(__dirname),
-      // Catch-all for internal library paths to bypass restrictive "exports" in package.json
-      '@cfpb/cfpb-design-system/src': resolve(
-        __dirname,
-        'node_modules/@cfpb/cfpb-design-system/src'
-      ),
-      // Helper for specifically accessing the new abstracts location
-      '@cfpb/cfpb-design-system/src/elements/abstracts': resolve(
-        __dirname,
-        'node_modules/@cfpb/cfpb-design-system/src/elements/abstracts/index.scss'
-      )
-    }
-  },
-  plugins: [
+export default defineConfig(({ mode }) => {
+  const plugins: Plugin[] = [
     eslintPlugin(),
     {
       name: 'svg-raw-loader',
@@ -50,70 +35,92 @@ export default defineConfig(() => ({
     dts({
       insertTypesEntry: true
     }),
-    VitePluginReactRemoveAttributes({
-      attributes: ['data-testid']
-    })
-  ],
-  css: {
-    postcss: {
-      plugins: [processIcons as any]
-    }
-  },
-  test: {
-    globals: true,
-    environment: 'jsdom',
-    // This ensures Vitest uses the same plugin pipeline as Vite
-    transformMode: {
-      web: [/.[tj]sx?$/]
+    mode === 'test'
+      ? null
+      : VitePluginReactRemoveAttributes({
+          attributes: ['data-testid']
+        })
+  ].filter(Boolean) as Plugin[];
+
+  return {
+    publicDir: false,
+    resolve: {
+      alias: {
+        '~': resolve(__dirname),
+        // Catch-all for internal library paths to bypass restrictive "exports" in package.json
+        '@cfpb/cfpb-design-system/src': resolve(
+          __dirname,
+          'node_modules/@cfpb/cfpb-design-system/src'
+        ),
+        // Helper for specifically accessing the new abstracts location
+        '@cfpb/cfpb-design-system/src/elements/abstracts': resolve(
+          __dirname,
+          'node_modules/@cfpb/cfpb-design-system/src/elements/abstracts/index.scss'
+        )
+      }
     },
-    css: true,
-    server: {
+    plugins,
+    css: {
+      postcss: {
+        plugins: [processIcons as any]
+      }
+    },
+    test: {
+      globals: true,
+      environment: 'jsdom',
+      // This ensures Vitest uses the same plugin pipeline as Vite
+      transformMode: {
+        web: [/.[tj]sx?$/]
+      },
+      css: true,
+      server: {
+        deps: {
+          inline: ['@cfpb', 'vite-plugin-svgr']
+        }
+      },
+      clearMocks: true,
+      coverage: {
+        provider: 'istanbul',
+        enabled: true,
+        '100': true,
+        reporter: ['text', 'lcov'],
+        reportsDirectory: 'coverage',
+        all: false
+      },
       deps: {
-        inline: ['@cfpb', 'vite-plugin-svgr']
-      }
-    },
-    clearMocks: true,
-    coverage: {
-      provider: 'istanbul',
-      enabled: true,
-      '100': true,
-      reporter: ['text', 'lcov'],
-      reportsDirectory: 'coverage',
-      all: false
-    },
-    deps: {
-      optimizer: {
-        web: {
-          include: ['vite-plugin-svgr']
-        }
-      }
-    }
-  },
-  build: {
-    lib: {
-      entry: resolve('src', 'index.ts'),
-      name,
-      formats: ['es', 'cjs'],
-      fileName: (format): string => `index.${format === 'es' ? 'mjs' : 'js'}`
-    },
-    rollupOptions: {
-      external: ['react', 'react-dom', 'react-router-dom'],
-      output: {
-        // This prevents the "flat" file explosion for icons/assets in the root
-        assetFileNames: 'assets/[name].[ext]',
-        chunkFileNames: 'chunks/[name]-[hash].js',
-        globals: {
-          react: 'React',
-          'react-dom': 'ReactDOM',
-          'react-router-dom': 'ReactRouterDOM'
+        optimizer: {
+          web: {
+            include: ['vite-plugin-svgr']
+          }
         }
       }
     },
-    optimizeDeps: {
-      exclude: ['react', 'react-dom', 'react-router-dom']
-    },
-    esbuild: {
-      minify: true
+    build: {
+      lib: {
+        entry: resolve('src', 'index.ts'),
+        name,
+        formats: ['es', 'cjs'],
+        fileName: (format): string => `index.${format === 'es' ? 'mjs' : 'js'}`
+      },
+      rollupOptions: {
+        external: ['react', 'react-dom', 'react-router-dom'],
+        output: {
+          // This prevents the "flat" file explosion for icons/assets in the root
+          assetFileNames: 'assets/[name].[ext]',
+          chunkFileNames: 'chunks/[name]-[hash].js',
+          globals: {
+            react: 'React',
+            'react-dom': 'ReactDOM',
+            'react-router-dom': 'ReactRouterDOM'
+          }
+        }
+      },
+      optimizeDeps: {
+        exclude: ['react', 'react-dom', 'react-router-dom']
+      },
+      esbuild: {
+        minify: true
+      }
     }
-  }
-}));
+  };
+});


### PR DESCRIPTION
## Changes

- updates test coverage for the following components:
 - Button
 - Expandables
- updated vitest test setup so we don't have to mock the svg icon hook and the test runner can load svgs

## How to test this PR

1. pull down code
2. yarn test Button
3. yarn test Expandable
4. Tests should still pass
5. look at the demo site and confirm the buttons and expandables behave as desired

## Screenshots
<img width="691" height="64" alt="Screenshot 2026-02-03 at 7 23 57 AM" src="https://github.com/user-attachments/assets/12e30dc5-d069-4c0d-8886-f7e037f99810" />
<img width="705" height="109" alt="Screenshot 2026-02-03 at 7 23 34 AM" src="https://github.com/user-attachments/assets/da50623b-58b0-4ce1-b8bf-0adbb8119187" />

## Notes

-
