### PR TITLE
Fixing bug in Link styled as a button

### DIFF
--- a/src/components/Buttons/Button.tsx
+++ b/src/components/Buttons/Button.tsx
@@ -60,12 +60,12 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProperties>(
       iconRight,
       ...properties
     },
-    reference, // Receive the ref as the second argument
+    reference // Receive the ref as the second argument
   ): JSX.Element => {
     const styles = [
       ...baseStyles,
       ...appearanceStyles[appearance],
-      ...sizeStyles[size],
+      ...sizeStyles[size]
     ];
     if (asLink) styles.push('a-btn--link');
     if (className) styles.push(className);
@@ -74,28 +74,28 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProperties>(
     return (
       <button
         ref={reference} // Attach the forwarded ref here
-        type="button"
+        type='button'
         className={[...styles].join(' ')}
         {...properties}
       >
-        {iconLeft ? (
+        {!!iconLeft && (
           <Icon
             name={iconLeft}
             isPresentational
-            data-testid="button-icon-left"
+            data-testid='button-icon-left'
           />
-        ) : null}
+        )}
         {iconLeft || iconRight ? <span>{label}</span> : label}
-        {iconRight ? (
+        {!!iconRight && (
           <Icon
             name={iconRight}
             isPresentational
-            data-testid="button-icon-right"
+            data-testid='button-icon-right'
           />
-        ) : null}
+        )}
       </button>
     );
-  },
+  }
 );
 
 // Optional: Set displayName for better debugging in React DevTools

--- a/src/components/Buttons/Buttons.stories.tsx
+++ b/src/components/Buttons/Buttons.stories.tsx
@@ -79,7 +79,7 @@ export const StaticIconButtons: Story = {
           appearance='secondary'
         />
       </ButtonGroup>
-      <br/>
+      <br />
       <Button iconRight='upload' label='Upload file' />
     </>
   )
@@ -99,13 +99,30 @@ export const ButtonsGroup: Story = {
   render: arguments_ => (
     <>
       <ButtonGroup>
-        <Button key='Go back' {...arguments_} appearance='secondary' label='Go back' iconLeft='left' />
-        <Button key='Continue' {...arguments_} label='Continue' iconRight='right' />
+        <Button
+          key='Go back'
+          {...arguments_}
+          appearance='secondary'
+          label='Go back'
+          iconLeft='left'
+        />
+        <Button
+          key='Continue'
+          {...arguments_}
+          label='Continue'
+          iconRight='right'
+        />
       </ButtonGroup>
       <br />
       <ButtonGroup>
         <Button key='Submit' {...arguments_} label='Submit' />
-        <Button appearance='warning' asLink key='Clear form' {...arguments_} label='Clear form' />
+        <Button
+          appearance='warning'
+          asLink
+          key='Clear form'
+          {...arguments_}
+          label='Clear form'
+        />
       </ButtonGroup>
     </>
   )
@@ -126,7 +143,7 @@ export const ButtonLink: Story = {
   render: arguments_ => (
     <ButtonGroup>
       <Link
-        className='a-btn'
+        asButton
         href='/'
         label='Link styled as a button'
         iconRight='download'
@@ -141,5 +158,3 @@ export const ButtonLink: Story = {
     </ButtonGroup>
   )
 };
-
-

--- a/src/components/Link/Link.test.tsx
+++ b/src/components/Link/Link.test.tsx
@@ -27,12 +27,14 @@ describe('<Link />', () => {
     render(<Link {...linkBaseProperties} isJump />);
     const link = screen.getByTestId(testId);
     expect(link).toHaveClass('a-link--jump');
+    expect(screen.getByText('some link')).toHaveClass('a-link__text');
   });
 
   it('Option: leftIcon - it adds left icon', async () => {
     render(<Link {...linkBaseProperties} iconLeft='left' />);
     const link = screen.getByTestId(testId);
     expect(link).toHaveClass('a-link');
+    expect(screen.getByText('some link')).toHaveClass('a-link__text');
     expect(await screen.findByTestId('link-icon-left')).toBeInTheDocument();
   });
 
@@ -40,6 +42,24 @@ describe('<Link />', () => {
     render(<Link {...linkBaseProperties} iconRight='right' />);
     const link = screen.getByTestId(testId);
     expect(link).toHaveClass('a-link');
+    expect(screen.getByText('some link')).toHaveClass('a-link__text');
+    expect(await screen.findByTestId('link-icon-right')).toBeInTheDocument();
+  });
+
+  it('Option: asButton - it does not add a-link and wraps the label', () => {
+    render(<Link {...linkBaseProperties} asButton />);
+    const link = screen.getByTestId(testId);
+    expect(link).toHaveClass('a-btn');
+    expect(link).not.toHaveClass('a-link');
+    expect(screen.getByText('some link')).toHaveClass('a-link__text');
+  });
+
+  it('Option: asButton with icon - it keeps a-btn, skips a-link, and shows icon', async () => {
+    render(<Link {...linkBaseProperties} asButton iconRight='right' />);
+    const link = screen.getByTestId(testId);
+    expect(link).toHaveClass('a-btn');
+    expect(link).not.toHaveClass('a-link');
+    expect(screen.getByText('some link')).toHaveClass('a-link__text');
     expect(await screen.findByTestId('link-icon-right')).toBeInTheDocument();
   });
 

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -65,17 +65,17 @@ export default function Link({
   type = 'default',
   ...others
 }: LinkProperties): JSXElement {
-  const cname = [others.className];
-
-  if (asButton || type === 'destructive') {
-    cname.push('a-btn');
-  }
-
-  if (type === 'destructive') {
-    cname.push('a-btn a-btn--link a-btn--warning');
-  }
-  if (isJump) cname.push('a-link--jump');
-  if (iconLeft || iconRight || isJump) cname.push('a-link');
+  const hasIcons = Boolean(iconLeft ?? iconRight);
+  const shouldUseLinkStyles = !asButton && (hasIcons || isJump);
+  const shouldWrapLabel = asButton || shouldUseLinkStyles;
+  const labelNode = shouldWrapLabel ? <LinkText>{label}</LinkText> : label;
+  const cname = classnames(others.className, {
+    'a-btn': asButton || type === 'destructive',
+    'a-btn--link': type === 'destructive',
+    'a-btn--warning': type === 'destructive',
+    'a-link--jump': isJump,
+    'a-link': shouldUseLinkStyles
+  });
 
   if (isRouterLink) {
     if (!href) {
@@ -84,26 +84,22 @@ export default function Link({
       );
     }
     return (
-      <RouterLink to={href} {...others} className={classnames(cname)}>
+      <RouterLink to={href} {...others} className={cname}>
         {label}
       </RouterLink>
     );
   }
 
   return (
-    <a {...others} className={classnames(cname)} href={href}>
+    <a {...others} className={cname} href={href}>
       {children}
-      {iconLeft ? (
+      {!!iconLeft && (
         <Icon name={iconLeft} isPresentational data-testid='link-icon-left' />
-      ) : null}
-      {iconLeft || iconRight || isJump ? (
-        <span className='a-link__text'>{label}</span>
-      ) : (
-        label
       )}
-      {iconRight ? (
+      {labelNode}
+      {!!iconRight && (
         <Icon name={iconRight} isPresentational data-testid='link-icon-right' />
-      ) : null}
+      )}
     </a>
   );
 }


### PR DESCRIPTION
During the Link refactor, I introduced a new bug and caused the Link styled as a button to have an underline in it.

## Changes
- This fixes the Link and removes the a-link class when the asButton parameter is passed to the component

## How to test this PR

1. Go to preview and confirm the Link as button does not have the underlined text

## Screenshots
<img width="466" height="91" alt="Screenshot 2026-02-06 at 2 02 35 PM" src="https://github.com/user-attachments/assets/3501ca07-ef1d-47bf-bb9f-66fbe348e704" />

## Notes

-
