### PR TITLE
fix broken storybook test

### DIFF
--- a/src/components/Fieldset/fieldset.stories.tsx
+++ b/src/components/Fieldset/fieldset.stories.tsx
@@ -147,8 +147,9 @@ export const WithRadioButtons: Story = {
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const radioA = canvas.getByRole('radio', { name: /choice a/i });
-    const radioB = canvas.getByRole('radio', { name: /choice b/i });
+    const radioButtons = canvas.queryAllByRole('radio', { name: /label/i });
+    const radioA = radioButtons[0];
+    const radioB = radioButtons[1];
 
     await waitFor(() => expect(radioA).not.toBeChecked());
     await waitFor(() => expect(radioB).not.toBeChecked());


### PR DESCRIPTION
The storybook interaction test didn't get updated completely. 

This PR fixes that.

To test

yarn install
yarn start

go to http://localhost:6006/?path=/story/components-draft-fieldsets--with-radio-buttons

the test in storybook should pass