### PR TITLE
revert button styles and example from responsive menu

### DIFF
--- a/src/components/ResponsiveMenu/responsive-menu.scss
+++ b/src/components/ResponsiveMenu/responsive-menu.scss
@@ -182,6 +182,11 @@ $max-width: $breakpoint - 0.0625em;
           }
         }
 
+        .a-btn {
+          font-weight: 600;
+          letter-spacing: 1px;
+        }
+
         .a-btn--link {
           text-decoration: none;
           font-size: 14px;

--- a/src/components/ResponsiveMenu/responsive-menu.test.tsx
+++ b/src/components/ResponsiveMenu/responsive-menu.test.tsx
@@ -47,7 +47,7 @@ describe('ResponsiveMenu', () => {
     expect(screen.getByText('Home')).toBeInTheDocument();
     expect(screen.getByText('Filing')).toBeInTheDocument();
     expect(screen.getByText('John Sample')).toBeInTheDocument();
-    expect(screen.getByText('Log Out')).toBeInTheDocument();
+    expect(screen.getByText('LOG OUT')).toBeInTheDocument();
   });
 
   it('toggles menu visibility on button click', () => {

--- a/src/components/ResponsiveMenu/responsive-menu.tsx
+++ b/src/components/ResponsiveMenu/responsive-menu.tsx
@@ -153,7 +153,7 @@ export const ExampleLinks: React.ReactNode[] = [
     label='John Sample'
   />,
   <Button
-    label='Log Out'
+    label='LOG OUT'
     isLink
     onClick={(): void => {
       /* Empty*/


### PR DESCRIPTION
revert button styles and example from responsive menu

## Changes

- put back css for buttons that appear in responsive menu
- put back LOG OUT text for button example

## How to test this PR

1. go to demo responsive menu example
 https://cfpb.github.io/design-system-react/pr-previews/pr-517/?path=/docs/components-draft-responsivemenu--overview

## Screenshots

## Notes

-
