### PR TITLE
fix mobile responsive menu example

### DIFF
--- a/src/components/ResponsiveMenu/responsive-menu.scss
+++ b/src/components/ResponsiveMenu/responsive-menu.scss
@@ -193,10 +193,6 @@ $max-width: $breakpoint - 0.0625em;
           justify-content: left;
           line-height: 22px;
           width: auto;
-
-          @media (min-width: $breakpoint) {
-            line-height: 18px;
-          }
         }
 
         & > *:first-child {

--- a/src/components/ResponsiveMenu/responsive-menu.tsx
+++ b/src/components/ResponsiveMenu/responsive-menu.tsx
@@ -146,12 +146,9 @@ export const ExampleLinks: React.ReactNode[] = [
     href='/filing'
     label='Filing'
   />,
-  <Link
-    key='profile'
-    className='nav-item profile'
-    href='/profile'
-    label='John Sample'
-  />,
+  <Link key='profile' className='nav-item profile' href='/profile'>
+    <span>John Sample</span>
+  </Link>,
   <Button
     label='LOG OUT'
     isLink


### PR DESCRIPTION
Fixing a bug in mobile responsive menu.  

Removing the span breaks the targeted css that hides the span and replaces it with "Profile"


## Changes

- Puts back span tag around "John Sample" 
- remove line height override to make "LOG OUT" appear on same as other links
 
## How to test this PR

1. Go to demo site https://cfpb.github.io/design-system-react/pr-previews/pr-519/?path=/docs/components-draft-responsivemenu--overview 
2. compare with production https://cfpb.github.io/design-system-react/?path=/docs/components-draft-responsivemenu--overview

## Screenshots
Broken
<img width="866" height="296" alt="Screenshot 2026-03-04 at 9 42 01 AM" src="https://github.com/user-attachments/assets/f4a202d6-18b2-4b58-ab36-465daafc3925" />
<img width="1066" height="307" alt="Screenshot 2026-03-04 at 9 45 43 AM" src="https://github.com/user-attachments/assets/6ba9f7a7-56ef-4cbd-87ec-e4a62784ea87" />

Fixed:
<img width="1061" height="350" alt="Screenshot 2026-03-04 at 9 43 58 AM" src="https://github.com/user-attachments/assets/3d20fc20-aca2-488d-907f-90e95cddc8e0" />
<img width="714" height="278" alt="Screenshot 2026-03-04 at 9 43 42 AM" src="https://github.com/user-attachments/assets/ab7ba14d-7015-4ded-b869-28d59a82b0e9" />



## Notes

-  I think having the specific overrides to hide and replace the text span in the menu and replace it with the "Profile" text via CSS should not belong in this repo.  It seems like an overly specific use case.   In your apps, you could just dynamically change the text supplied to the component based on the current window width / viewport.
https://github.com/cfpb/design-system-react/blob/main/src/components/ResponsiveMenu/responsive-menu.scss#L214
