### PR TITLE
Use Link component in breadcrumbs

### DIFF
--- a/src/components/Breadcrumb/breadcrumb.tsx
+++ b/src/components/Breadcrumb/breadcrumb.tsx
@@ -1,6 +1,7 @@
 import classnames from 'classnames';
 import type { HTMLAttributes } from 'react';
 import { Fragment, JSX } from 'react';
+import Link from '../Link/link';
 import './breadcrumb.scss';
 
 export interface BreadcrumbCrumb {
@@ -40,9 +41,9 @@ export const Breadcrumb = ({
                 {` ${crumb.label} `}
               </span>
             ) : (
-              <a className='m-breadcrumbs__crumb' href={crumb.href}>
+              <Link className='m-breadcrumbs__crumb' href={crumb.href}>
                 {` ${crumb.label} `}
-              </a>
+              </Link>
             )}
           </Fragment>
         ))}


### PR DESCRIPTION
Using the Link component for navigation simplifies integration with router libraries.

## Changes

- Use DSR Link instead of `<a>` in breadcrumbs

## How to test this PR

1. Breadcrumb component should be visually / functionally unchanged


