### PR TITLE
Update Layout component

### DIFF
--- a/src/components/Layout/layout-content.stories.tsx
+++ b/src/components/Layout/layout-content.stories.tsx
@@ -52,18 +52,8 @@ export const Content: Story = {
     flushAllOnSmall: false,
   },
   render: (properties) => (
-    <Layout.Main>
+    <Layout.Main layout='2-1'>
       <Layout.Wrapper>
-        <Layout.Sidebar>
-          <div>
-            <h2>Layout.Sidebar</h2>
-            <ul>
-              <li>Item 1</li>
-              <li>Item 2</li>
-              <li>Item 3</li>
-            </ul>
-          </div>
-        </Layout.Sidebar>
         <Layout.Content {...properties}>
           <h1>Layout.Content</h1>
           <p>
@@ -73,6 +63,63 @@ export const Content: Story = {
             veritatis eos, mollitia possimus error earum?
           </p>
         </Layout.Content>
+        <Layout.Sidebar>
+          <div>
+            <h2>Layout.Sidebar</h2>
+            <ul>
+              <li>Item 1</li>
+              <li>Item 2</li>
+              <li>Item 3</li>
+            </ul>
+            <h2>Layout.Sidebar</h2>
+            <ul>
+              <li>Item 1</li>
+              <li>Item 2</li>
+              <li>Item 3</li>
+            </ul>
+            <h2>Layout.Sidebar</h2>
+            <ul>
+              <li>Item 1</li>
+              <li>Item 2</li>
+              <li>Item 3</li>
+            </ul><h2>Layout.Sidebar</h2>
+            <ul>
+              <li>Item 1</li>
+              <li>Item 2</li>
+              <li>Item 3</li>
+            </ul>
+            <h2>Layout.Sidebar</h2>
+            <ul>
+              <li>Item 1</li>
+              <li>Item 2</li>
+              <li>Item 3</li>
+            </ul>
+            <h2>Layout.Sidebar</h2>
+            <ul>
+              <li>Item 1</li>
+              <li>Item 2</li>
+              <li>Item 3</li>
+            </ul>
+            <h2>Layout.Sidebar</h2>
+            <ul>
+              <li>Item 1</li>
+              <li>Item 2</li>
+              <li>Item 3</li>
+            </ul>
+            <h2>Layout.Sidebar</h2>
+            <ul>
+              <li>Item 1</li>
+              <li>Item 2</li>
+              <li>Item 3</li>
+            </ul>
+            <h2>Layout.Sidebar</h2>
+            <ul>
+              <li>Item 1</li>
+              <li>Item 2</li>
+              <li>Item 3</li>
+            </ul>
+          </div>
+        </Layout.Sidebar>
       </Layout.Wrapper>
     </Layout.Main>
   ),

--- a/src/components/Layout/layout-main.stories.tsx
+++ b/src/components/Layout/layout-main.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { ReactElement } from 'react';
 import { Layout } from '~/src/index';
+import type { LayoutMainProperties } from './layout-main';
 
 const meta: Meta<typeof Layout.Main> = {
   title: 'Components (Draft)/Layout/Main',
@@ -40,6 +42,8 @@ import Layout from './Layout<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;< /Layout.Sidebar ><br/>
 &nbsp;&nbsp;< /Layout.Wrapper ><br/>
 < /Layout.Main ><br/>
+
+**Note:** For \`layout="1-3"\` (sidebar on the left), put \`Layout.Sidebar\` **before** \`Layout.Content\` inside \`Layout.Wrapper\`. For \`layout="2-1"\`, put **main first**, then sidebar—matching the [CFPB markup](https://cfpb.github.io/design-system/development/main-content-and-sidebars).
 `,
       },
     },
@@ -50,64 +54,93 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+const exampleContent = (
+  <Layout.Content key='content'>
+    <h1>Content</h1>
+    <p>
+      Lorem ipsum, dolor sit amet consectetur adipisicing elit. Quaerat alias
+      eum ut officiis optio similique explicabo cupiditate architecto
+      voluptatem nostrum recusandae, eaque consectetur iure, veritatis eos,
+      mollitia possimus error earum?
+    </p>
+  </Layout.Content>
+);
+
+const exampleSidebar = (
+  <Layout.Sidebar key='sidebar'>
+    <div>
+      <h2>Sidebar</h2>
+      <ul>
+        <li>Item 1</li>
+        <li>Item 2</li>
+        <li>Item 3</li>
+      </ul>
+      <h2>Sidebar</h2>
+      <ul>
+        <li>Item 1</li>
+        <li>Item 2</li>
+        <li>Item 3</li>
+      </ul>
+      <h2>Sidebar</h2>
+      <ul>
+        <li>Item 1</li>
+        <li>Item 2</li>
+        <li>Item 3</li>
+      </ul>
+      <h2>Sidebar</h2>
+      <ul>
+        <li>Item 1</li>
+        <li>Item 2</li>
+        <li>Item 3</li>
+      </ul>
+      <h2>Sidebar</h2>
+      <ul>
+        <li>Item 1</li>
+        <li>Item 2</li>
+        <li>Item 3</li>
+      </ul>
+      <h2>Sidebar</h2>
+      <ul>
+        <li>Item 1</li>
+        <li>Item 2</li>
+        <li>Item 3</li>
+      </ul>
+      <h2>Sidebar</h2>
+      <ul>
+        <li>Item 1</li>
+        <li>Item 2</li>
+        <li>Item 3</li>
+      </ul>
+    </div>
+  </Layout.Sidebar>
+);
+
+function renderMainLayout(
+  properties: LayoutMainProperties,
+): ReactElement {
+  const layout = properties.layout ?? '2-1';
+  const columnChildren =
+    layout === '1-3'
+      ? [exampleSidebar, exampleContent]
+      : [exampleContent, exampleSidebar];
+
+  return (
+    <Layout.Main {...properties}>
+      <Layout.Wrapper>{columnChildren}</Layout.Wrapper>
+    </Layout.Main>
+  );
+}
+
 export const Layout_2_1: Story = {
   args: {
     layout: '2-1',
   },
-  render: (properties) => (
-    <Layout.Main {...properties}>
-      <Layout.Wrapper>
-        <Layout.Content>
-          <h1>Content</h1>
-          <p>
-            Lorem ipsum, dolor sit amet consectetur adipisicing elit. Quaerat
-            alias eum ut officiis optio similique explicabo cupiditate
-            architecto voluptatem nostrum recusandae, eaque consectetur iure,
-            veritatis eos, mollitia possimus error earum?
-          </p>
-        </Layout.Content>
-        <Layout.Sidebar>
-          <div>
-            <h2>Sidebar</h2>
-            <ul>
-              <li>Item 1</li>
-              <li>Item 2</li>
-              <li>Item 3</li>
-            </ul>
-          </div>
-        </Layout.Sidebar>
-      </Layout.Wrapper>
-    </Layout.Main>
-  ),
+  render: (properties) => renderMainLayout(properties),
 };
 
 export const Layout_1_3: Story = {
   args: {
     layout: '1-3',
   },
-  render: (properties) => (
-    <Layout.Main {...properties}>
-      <Layout.Wrapper>
-        <Layout.Sidebar>
-          <div>
-            <h2>Sidebar</h2>
-            <ul>
-              <li>Item 1</li>
-              <li>Item 2</li>
-              <li>Item 3</li>
-            </ul>
-          </div>
-        </Layout.Sidebar>
-        <Layout.Content>
-          <h1>Content</h1>
-          <p>
-            Lorem ipsum, dolor sit amet consectetur adipisicing elit. Quaerat
-            alias eum ut officiis optio similique explicabo cupiditate
-            architecto voluptatem nostrum recusandae, eaque consectetur iure,
-            veritatis eos, mollitia possimus error earum?
-          </p>
-        </Layout.Content>
-      </Layout.Wrapper>
-    </Layout.Main>
-  ),
+  render: (properties) => renderMainLayout(properties),
 };

--- a/src/components/Layout/layout-sidebar.stories.tsx
+++ b/src/components/Layout/layout-sidebar.stories.tsx
@@ -53,8 +53,17 @@ export const Sidebar: Story = {
     flushAllOnSmall: false,
   },
   render: (properties) => (
-    <Layout.Main>
+    <Layout.Main layout='2-1'>
       <Layout.Wrapper>
+        <Layout.Content>
+          <h1>Layout.Content</h1>
+          <p>
+            Lorem ipsum, dolor sit amet consectetur adipisicing elit. Quaerat
+            alias eum ut officiis optio similique explicabo cupiditate
+            architecto voluptatem nostrum recusandae, eaque consectetur iure,
+            veritatis eos, mollitia possimus error earum?
+          </p>
+        </Layout.Content>
         <Layout.Sidebar {...properties}>
           <div>
             <h2>Layout.Sidebar</h2>
@@ -65,15 +74,6 @@ export const Sidebar: Story = {
             </ul>
           </div>
         </Layout.Sidebar>
-        <Layout.Content>
-          <h1>Layout.Content</h1>
-          <p>
-            Lorem ipsum, dolor sit amet consectetur adipisicing elit. Quaerat
-            alias eum ut officiis optio similique explicabo cupiditate
-            architecto voluptatem nostrum recusandae, eaque consectetur iure,
-            veritatis eos, mollitia possimus error earum?
-          </p>
-        </Layout.Content>
       </Layout.Wrapper>
     </Layout.Main>
   ),

--- a/src/components/Layout/layout-wrapper.stories.tsx
+++ b/src/components/Layout/layout-wrapper.stories.tsx
@@ -42,7 +42,17 @@ type Story = StoryObj<typeof meta>;
 
 export const Wrapper: Story = {
   args: {
+    // Order matches default Layout.Main layout "2-1" (main first, then sidebar).
     children: [
+      <Layout.Content key='content'>
+        <h1>Layout.Content</h1>
+        <p>
+          Lorem ipsum, dolor sit amet consectetur adipisicing elit. Quaerat
+          alias eum ut officiis optio similique explicabo cupiditate architecto
+          voluptatem nostrum recusandae, eaque consectetur iure, veritatis eos,
+          mollitia possimus error earum?
+        </p>
+      </Layout.Content>,
       <Layout.Sidebar key='sidebar'>
         <div>
           <h2>Layout.Sidebar</h2>
@@ -53,15 +63,6 @@ export const Wrapper: Story = {
           </ul>
         </div>
       </Layout.Sidebar>,
-      <Layout.Content key='content'>
-        <h1>Layout.Content</h1>
-        <p>
-          Lorem ipsum, dolor sit amet consectetur adipisicing elit. Quaerat
-          alias eum ut officiis optio similique explicabo cupiditate architecto
-          voluptatem nostrum recusandae, eaque consectetur iure, veritatis eos,
-          mollitia possimus error earum?
-        </p>
-      </Layout.Content>,
     ],
   },
   render: ({ children }) => (

--- a/src/components/Layout/layout.scss
+++ b/src/components/Layout/layout.scss
@@ -5,3 +5,60 @@
     margin-right: 0 !important;
   }
 }
+
+// At the two-column breakpoint, use flex so main and sidebar share the row height of the
+// taller column. The vertical divider is drawn from `.content__main::after` with `bottom: 0`,
+// so it only reaches the bottom of `.content__main`; stretching that box matches the divider
+// to the full sidebar/main height (CFPB DS uses inline-block, which does not equalize height).
+@media only screen and (width >= 56.3125em) {
+  .content--1-3 .wrapper,
+  .content--2-1 .wrapper {
+    align-items: stretch;
+    display: flex;
+  }
+
+  .content--1-3 .wrapper > .content__main,
+  .content--1-3 .wrapper > .content__sidebar,
+  .content--2-1 .wrapper > .content__main,
+  .content--2-1 .wrapper > .content__sidebar {
+    display: block;
+    margin-right: 0 !important;
+  }
+
+  .content--1-3 .wrapper > .content__sidebar {
+    flex: 0 0 25%;
+    max-width: 25%;
+  }
+
+  .content--1-3 .wrapper > .content__main {
+    flex: 0 0 75%;
+    max-width: 75%;
+  }
+
+  .content--2-1 .wrapper > .content__main {
+    flex: 0 0 66.6667%;
+    max-width: 66.6667%;
+  }
+
+  .content--2-1 .wrapper > .content__sidebar {
+    flex: 0 0 33.3333%;
+    max-width: 33.3333%;
+  }
+
+  // CFPB DS 5.3.2 defines the column divider via `.content__main::after` for `content--1-3`
+  // but only emits `right: -1.875em` for `content--2-1` (no `content`, border, or positioning).
+  // Mirror the 1-3 rule so the vertical rule appears between main and a right-hand sidebar.
+  .content--2-1 .content__main {
+    position: relative;
+  }
+
+  .content--2-1 .content__main::after {
+    border-right: 1px solid var(--content-main-border);
+    bottom: 0;
+    content: '';
+    position: absolute;
+    right: -1.875em;
+    top: 2.8125em;
+    width: 0;
+  }
+}

--- a/src/components/Layout/layout.test.tsx
+++ b/src/components/Layout/layout.test.tsx
@@ -1,0 +1,169 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import Layout from './layout';
+
+describe('Layout.Main', () => {
+  it('renders main landmark with default 2-1 layout classes', () => {
+    render(
+      <Layout.Main>
+        <span>child</span>
+      </Layout.Main>,
+    );
+
+    const main = screen.getByRole('main');
+    expect(main).toHaveClass('content', 'content--2-1');
+    expect(main).toHaveAttribute('id', 'main');
+    expect(screen.getByText('child')).toBeInTheDocument();
+  });
+
+  it('applies 1-3 layout class when layout is 1-3', () => {
+    render(
+      <Layout.Main layout='1-3'>
+        <span>child</span>
+      </Layout.Main>,
+    );
+
+    expect(screen.getByRole('main')).toHaveClass('content--1-3');
+  });
+
+  it('accepts custom id and extra classes', () => {
+    render(
+      <Layout.Main id='page-main' classes='extra-class'>
+        <span>child</span>
+      </Layout.Main>,
+    );
+
+    const main = screen.getByRole('main');
+    expect(main).toHaveAttribute('id', 'page-main');
+    expect(main).toHaveClass('extra-class');
+  });
+});
+
+describe('Layout.Wrapper', () => {
+  it('renders wrapper class and passes through div attributes', () => {
+    render(
+      <Layout.Wrapper data-testid='wrap' aria-label='Page'>
+        inner
+      </Layout.Wrapper>,
+    );
+
+    const wrap = screen.getByTestId('wrap');
+    expect(wrap).toHaveClass('wrapper');
+    expect(wrap).toHaveAttribute('aria-label', 'Page');
+    expect(wrap).toHaveTextContent('inner');
+  });
+});
+
+describe('Layout.Content', () => {
+  it('renders content__main and optional flush modifiers', () => {
+    const { rerender } = render(
+      <Layout.Content data-testid='content'>
+        body
+      </Layout.Content>,
+    );
+
+    let node = screen.getByTestId('content');
+    expect(node).toHaveClass('content__main');
+    expect(node).not.toHaveClass('content--flush-bottom');
+
+    rerender(
+      <Layout.Content
+        data-testid='content'
+        flushBottom
+        flushTopOnSmall
+        flushAllOnSmall
+      >
+        body
+      </Layout.Content>,
+    );
+
+    node = screen.getByTestId('content');
+    expect(node).toHaveClass(
+      'content__main',
+      'content--flush-bottom',
+      'content--flush-top-on-small',
+      'content--flush-all-on-small',
+    );
+  });
+});
+
+describe('Layout.Sidebar', () => {
+  it('renders aside with sidebar classes and optional flush modifiers', () => {
+    const { rerender } = render(
+      <Layout.Sidebar data-testid='side'>nav</Layout.Sidebar>,
+    );
+
+    let aside = screen.getByTestId('side');
+    expect(aside.tagName).toBe('ASIDE');
+    expect(aside).toHaveClass('sidebar', 'content__sidebar', 'o-sidebar-content');
+    expect(aside).not.toHaveClass('content--flush-bottom');
+
+    rerender(
+      <Layout.Sidebar
+        data-testid='side'
+        flushBottom
+        flushTopOnSmall
+        flushAllOnSmall
+      >
+        nav
+      </Layout.Sidebar>,
+    );
+
+    aside = screen.getByTestId('side');
+    expect(aside).toHaveClass(
+      'content--flush-bottom',
+      'content--flush-top-on-small',
+      'content--flush-all-on-small',
+    );
+  });
+});
+
+describe('Layout composition (CFPB DOM order)', () => {
+  it('2-1: main column precedes sidebar in document order', () => {
+    render(
+      <Layout.Main layout='2-1'>
+        <Layout.Wrapper>
+          <Layout.Content data-testid='layout-main-col'>
+            <span>Main</span>
+          </Layout.Content>
+          <Layout.Sidebar data-testid='layout-sidebar-col'>
+            <span>Side</span>
+          </Layout.Sidebar>
+        </Layout.Wrapper>
+      </Layout.Main>,
+    );
+
+    const mainCol = screen.getByTestId('layout-main-col');
+    const sidebar = screen.getByTestId('layout-sidebar-col');
+    expect(
+      Boolean(
+        mainCol.compareDocumentPosition(sidebar) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ),
+    ).toBe(true);
+  });
+
+  it('1-3: sidebar precedes main column in document order', () => {
+    render(
+      <Layout.Main layout='1-3'>
+        <Layout.Wrapper>
+          <Layout.Sidebar data-testid='layout-sidebar-col'>
+            <span>Side</span>
+          </Layout.Sidebar>
+          <Layout.Content data-testid='layout-main-col'>
+            <span>Main</span>
+          </Layout.Content>
+        </Layout.Wrapper>
+      </Layout.Main>,
+    );
+
+    const mainCol = screen.getByTestId('layout-main-col');
+    const sidebar = screen.getByTestId('layout-sidebar-col');
+    expect(
+      Boolean(
+        sidebar.compareDocumentPosition(mainCol) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
# Summary of changes 

### Layout behavior (CSS) — `src/components/Layout/layout.scss`

- **2-1 divider:** The peer DS only outputs `right: -1.875em` on `.content--2-1 .content__main::after`, so the vertical rule never renders. We add the full `::after` rule (mirroring `1-3`, with `border-right` and `position: relative` on main).
- **Divider height:** DS uses `inline-block` columns, so `.content__main` is only as tall as its content and the `::after` line stops there. We make `.content--1-3 .wrapper` / `.content--2-1 .wrapper` a **flex** row with **`align-items: stretch`**, reset children to **`display: block`** and **`margin-right: 0`**, and set **`flex` / `max-width`** so the 25/75 and 66.67/33.33 splits stay aligned with the DS.
- **Overflow workaround (existing / retained):** From **`37.5625em`**, **`margin-right: 0 !important`** on `.content--2-1 .content__main` and `.content--1-3 .content__sidebar` (comment in file says this fixes content overflowing the sidebar).


### Storybook — examples match CFPB markup and Controls behavior
- Updated examples to display content with different heights to show the variable divider heights
- **`layout-main.stories.tsx`:** Shared `renderMainLayout()` so **`layout` in Controls** reorders **Sidebar vs Content** (`1-3` → sidebar first; `2-1` → main first). Docs note about DOM order.
- **`layout-wrapper.stories.tsx`:** Children order **Content then Sidebar** to match default **`2-1`**.
- **`layout-content.stories.tsx`**, **`layout-sidebar.stories.tsx`:** Same **2-1** order and explicit **`layout='2-1'`** on **`Layout.Main`**.

TODO:
 - remove overrides and fixes for the divider in 2-1 layout if it is fixed in DS upstream