### PR TITLE
Add responsive preview option

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -22,7 +22,9 @@ export default {
     options: {},
   },
 
-  features: {},
+  features: {
+    viewport: true,
+  },
 
   async viteFinal(config, { configType }) {
     config.base = process.env.BASE_PATH || config.base;

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -55,6 +55,89 @@ const getPreviewSource = (storyId) => {
   return url.toString();
 };
 
+const getFrameHeight = (frame) => {
+  const frameDocument = frame.contentDocument;
+
+  if (!frameDocument) return 0;
+
+  const { body, documentElement } = frameDocument;
+  const storyRoot = frameDocument.getElementById('storybook-root');
+
+  if (storyRoot) {
+    const bodyStyles = frame.contentWindow?.getComputedStyle(body);
+    const verticalPadding =
+      parseFloat(bodyStyles?.paddingTop ?? '0') +
+      parseFloat(bodyStyles?.paddingBottom ?? '0');
+    const rootTop = storyRoot.getBoundingClientRect().top;
+    const contentBottom = Array.from(storyRoot.querySelectorAll('*')).reduce(
+      (bottom, element) =>
+        Math.max(bottom, element.getBoundingClientRect().bottom),
+      storyRoot.getBoundingClientRect().bottom,
+    );
+
+    return Math.ceil(
+      Math.max(
+        storyRoot.getBoundingClientRect().height,
+        storyRoot.scrollHeight,
+        storyRoot.offsetHeight,
+        contentBottom - rootTop,
+      ) + verticalPadding,
+    );
+  }
+
+  return Math.max(
+    body?.scrollHeight ?? 0,
+    body?.offsetHeight ?? 0,
+    documentElement?.scrollHeight ?? 0,
+    documentElement?.offsetHeight ?? 0,
+  );
+};
+
+const ResponsivePreviewFrame = ({ storyId, viewport }) => {
+  const [height, setHeight] = React.useState(240);
+
+  const updateHeight = React.useCallback((frame) => {
+    const measuredHeight = getFrameHeight(frame);
+
+    setHeight(Math.max(measuredHeight + 16, 160));
+  }, []);
+
+  return React.createElement('iframe', {
+    onLoad: (event) => {
+      const frame = event.currentTarget;
+      const frameWindow = frame.contentWindow;
+      const frameDocument = frame.contentDocument;
+
+      updateHeight(frame);
+      frameWindow?.requestAnimationFrame(() => updateHeight(frame));
+      frameWindow?.setTimeout(() => updateHeight(frame), 250);
+
+      frameWindow?.addEventListener('resize', () => updateHeight(frame));
+
+      if (frameWindow?.ResizeObserver && frameDocument) {
+        const observer = new frameWindow.ResizeObserver(() =>
+          updateHeight(frame),
+        );
+        const storyRoot = frameDocument.getElementById('storybook-root');
+
+        observer.observe(frameDocument.documentElement);
+        observer.observe(frameDocument.body);
+
+        if (storyRoot) observer.observe(storyRoot);
+      }
+    },
+    src: getPreviewSource(storyId),
+    title: `${viewport.name} preview`,
+    style: {
+      background: 'white',
+      border: '1px solid #d0d0ce',
+      boxSizing: 'border-box',
+      height,
+      width: viewport.styles.width,
+    },
+  });
+};
+
 const renderResponsivePreviews = (Story, context) => {
   if (shouldRenderSinglePreview(context)) {
     return React.createElement(Story);
@@ -95,16 +178,9 @@ const renderResponsivePreviews = (Story, context) => {
           },
           `${viewport.name} (${viewport.styles.width})`,
         ),
-        React.createElement('iframe', {
-          src: getPreviewSource(context.id),
-          title: `${viewport.name} preview`,
-          style: {
-            background: 'white',
-            border: '1px solid #d0d0ce',
-            boxSizing: 'border-box',
-            height: viewport.styles.height,
-            width: viewport.styles.width,
-          },
+        React.createElement(ResponsivePreviewFrame, {
+          storyId: context.id,
+          viewport,
         }),
       ),
     ),

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -2,8 +2,45 @@ import '@fontsource-variable/source-sans-3';
 import '../src/assets/styles/_shared.scss';
 import themeCFPB from './themeCFPB';
 
+const viewportOptions = {
+  phone: {
+    name: 'Phone',
+    styles: {
+      width: '390px',
+      height: '844px',
+    },
+    type: 'mobile',
+  },
+  tablet: {
+    name: 'Tablet',
+    styles: {
+      width: '768px',
+      height: '1024px',
+    },
+    type: 'tablet',
+  },
+  desktop: {
+    name: 'Desktop',
+    styles: {
+      width: '1280px',
+      height: '900px',
+    },
+    type: 'desktop',
+  },
+};
+
 export const preview = {
+  initialGlobals: {
+    viewport: {
+      value: 'responsive',
+    },
+  },
+
   parameters: {
+    viewport: {
+      options: viewportOptions,
+    },
+
     options: {
       // Determines the display order of Stories in the sidebar
       storySort: {

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,9 @@
+import React from 'react';
 import '@fontsource-variable/source-sans-3';
 import '../src/assets/styles/_shared.scss';
 import themeCFPB from './themeCFPB';
+
+const responsivePreviewQueryParameter = 'responsivePreview';
 
 const viewportOptions = {
   phone: {
@@ -29,12 +32,112 @@ const viewportOptions = {
   },
 };
 
-export const preview = {
-  initialGlobals: {
-    viewport: {
-      value: 'responsive',
+const responsivePreviewOptions = Object.entries(viewportOptions);
+
+const shouldRenderSinglePreview = (context) => {
+  const searchParameters = new URLSearchParams(globalThis.location.search);
+
+  return (
+    context.viewMode !== 'story' ||
+    context.globals.responsivePreview !== 'all' ||
+    searchParameters.get(responsivePreviewQueryParameter) === 'off'
+  );
+};
+
+const getPreviewSource = (storyId) => {
+  const url = new URL(globalThis.location.href);
+
+  url.search = '';
+  url.searchParams.set('id', storyId);
+  url.searchParams.set('viewMode', 'story');
+  url.searchParams.set(responsivePreviewQueryParameter, 'off');
+
+  return url.toString();
+};
+
+const renderResponsivePreviews = (Story, context) => {
+  if (shouldRenderSinglePreview(context)) {
+    return React.createElement(Story);
+  }
+
+  return React.createElement(
+    'div',
+    {
+      style: {
+        boxSizing: 'border-box',
+        display: 'grid',
+        gap: '24px',
+        overflowX: 'auto',
+        padding: '24px',
+      },
+    },
+    responsivePreviewOptions.map(([key, viewport]) =>
+      React.createElement(
+        'section',
+        {
+          key,
+          style: {
+            display: 'grid',
+            gap: '8px',
+            justifyItems: 'start',
+          },
+        },
+        React.createElement(
+          'div',
+          {
+            style: {
+              color: '#5a5d61',
+              fontFamily: 'Source Sans 3 Variable, sans-serif',
+              fontSize: '14px',
+              fontWeight: 600,
+              lineHeight: 1.25,
+            },
+          },
+          `${viewport.name} (${viewport.styles.width})`,
+        ),
+        React.createElement('iframe', {
+          src: getPreviewSource(context.id),
+          title: `${viewport.name} preview`,
+          style: {
+            background: 'white',
+            border: '1px solid #d0d0ce',
+            boxSizing: 'border-box',
+            height: viewport.styles.height,
+            width: viewport.styles.width,
+          },
+        }),
+      ),
+    ),
+  );
+};
+
+export const globalTypes = {
+  responsivePreview: {
+    name: 'Responsive preview',
+    description: 'Preview the current story at every configured viewport',
+    toolbar: {
+      icon: 'browser',
+      items: [
+        { value: 'single', title: 'Single viewport' },
+        { value: 'all', title: 'All viewports' },
+      ],
     },
   },
+};
+
+export const initialGlobals = {
+  responsivePreview: 'single',
+  viewport: {
+    value: 'responsive',
+  },
+};
+
+export const decorators = [renderResponsivePreviews];
+
+export const preview = {
+  globalTypes,
+
+  initialGlobals,
 
   parameters: {
     viewport: {
@@ -96,6 +199,8 @@ export const preview = {
   },
 
   tags: ['autodocs'],
+
+  decorators,
 };
 
 export default preview;

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -6,29 +6,29 @@ import themeCFPB from './themeCFPB';
 const responsivePreviewQueryParameter = 'responsivePreview';
 
 const viewportOptions = {
-  phone: {
-    name: 'Phone',
-    styles: {
-      width: '390px',
-      height: '844px',
-    },
-    type: 'mobile',
-  },
-  tablet: {
-    name: 'Tablet',
-    styles: {
-      width: '768px',
-      height: '1024px',
-    },
-    type: 'tablet',
-  },
   desktop: {
-    name: 'Desktop',
+    name: 'Desktop (901px and above)',
     styles: {
       width: '1280px',
       height: '900px',
     },
     type: 'desktop',
+  },
+  tablet: {
+    name: 'Tablet (601-900px)',
+    styles: {
+      width: '900px',
+      height: '1024px',
+    },
+    type: 'tablet',
+  },
+  phone: {
+    name: 'Phone (600px and below)',
+    styles: {
+      width: '600px',
+      height: '844px',
+    },
+    type: 'mobile',
   },
 };
 
@@ -176,7 +176,7 @@ const renderResponsivePreviews = (Story, context) => {
               lineHeight: 1.25,
             },
           },
-          `${viewport.name} (${viewport.styles.width})`,
+          `${viewport.name}`,
         ),
         React.createElement(ResponsivePreviewFrame, {
           storyId: context.id,


### PR DESCRIPTION
Addresses: #571 
Adds responsive previews as an option in the storybook interface to view them all at one time.

To test, go to a story, (You can't be on the overview page for a component since thats just a documentation page) select all viewports from the dropdown.
https://cfpb.github.io/design-system-react/pr-previews/pr-572/?path=/story/components-draft-heroes--with-illustration&globals=viewport.isRotated:!false


<img width="1478" height="1080" alt="Screenshot 2026-05-10 at 4 18 52 PM" src="https://github.com/user-attachments/assets/d95a3d2c-a8a0-45a8-af7c-7e5d1396d248" />
