### PR TITLE
Update Icon stories

### DIFF
--- a/src/components/Icon/icon.stories.tsx
+++ b/src/components/Icon/icon.stories.tsx
@@ -102,8 +102,9 @@ export const DocumentIcons = (): ReactElement => (
   <IconTable>{makeRows(documentIcons)}</IconTable>
 );
 
-export const FinancialProductsServicesAndConceptIcons =
-  (): ReactElement => <IconTable>{makeRows(financialIcons)}</IconTable>;
+export const FinancialProductsServicesAndConceptIcons = (): ReactElement => (
+  <IconTable>{makeRows(financialIcons)}</IconTable>
+);
 
 export const ExpenseIcons = (): ReactElement => (
   <IconTable>{makeRows(expenseIcons)}</IconTable>
@@ -131,9 +132,11 @@ export const IconWithText: Story = {
     return (
       <table>
         <thead>
-          <th>Text element</th>
-          <th>Icon with background</th>
-          <th>Icon without background</th>
+          <tr>
+            <th>Text element</th>
+            <th>Icon with background</th>
+            <th>Icon without background</th>
+          </tr>
         </thead>
         <tbody>
           {acceptableLevels.map(({ type, text }) => (


### PR DESCRIPTION
Fixes a silly linting warning.  th / table headers need to live inside a table row