### PR TITLE
hero component cleanup

### DIFF
--- a/src/components/Hero/hero-image.tsx
+++ b/src/components/Hero/hero-image.tsx
@@ -1,9 +1,19 @@
+import type { CSSProperties } from 'react';
 import type { JSXElement } from '../../types/jsx-element';
 
 interface HeroImageProperties {
   image?: string;
+  mobileImage?: string;
   altText?: string;
 }
+
+type HeroImageStyle = CSSProperties & {
+  '--m-hero-image'?: string;
+  '--m-hero-mobile-image'?: string;
+};
+
+const createBackgroundImageValue = (image: string): string =>
+  `url(${JSON.stringify(image)})`;
 
 /**
  * DS pattern: empty `.m-hero__image` with `background-image` (not `<img>`), so
@@ -12,9 +22,18 @@ interface HeroImageProperties {
  */
 export const HeroImage = ({
   image,
+  mobileImage,
   altText,
 }: HeroImageProperties): JSXElement => {
-  if (!image) return null;
+  if (!image && !mobileImage) return null;
+
+  const imageStyle: HeroImageStyle = {};
+
+  if (image) imageStyle['--m-hero-image'] = createBackgroundImageValue(image);
+  if (mobileImage) {
+    imageStyle['--m-hero-mobile-image'] =
+      createBackgroundImageValue(mobileImage);
+  }
 
   return (
     <div className='m-hero__image-wrapper'>
@@ -22,9 +41,7 @@ export const HeroImage = ({
         className='m-hero__image'
         role='img'
         aria-label={altText}
-        style={{
-          backgroundImage: `url(${JSON.stringify(image)})`,
-        }}
+        style={imageStyle}
       />
     </div>
   );

--- a/src/components/Hero/hero.scss
+++ b/src/components/Hero/hero.scss
@@ -4,6 +4,24 @@
   background-color: var(--gray-30);
 }
 
+.m-hero__image {
+  background-image: var(--m-hero-mobile-image, var(--m-hero-image));
+}
+
+.m-hero--overlay .m-hero__wrapper {
+  background-image: none;
+}
+
+@media screen and (min-width: 37.5625em) {
+  .m-hero__image {
+    background-image: var(--m-hero-image, var(--m-hero-mobile-image));
+  }
+
+  .m-hero--overlay .m-hero__wrapper {
+    background-image: var(--m-hero-wrapper-image);
+  }
+}
+
 // Illustration slot: match common DS hero artwork (940×390).
 //
 // Production DS/Jinja pages often set this on an empty `.m-hero__image` with `background-image`,

--- a/src/components/Hero/hero.stories.tsx
+++ b/src/components/Hero/hero.stories.tsx
@@ -32,7 +32,7 @@ export const WithIllustration: Story = {
   args: {
     heading: '41 characters max for a one-line heading',
     image:
-      'https://cfpb.github.io/design-system/images/uploads/hero_illustration_example_keys.png',
+      'https://cfpb.github.io/design-system/images/uploads/design_system_illustration_hero_example.png',
     subheading:
       'This text has a recommended count of 165-186 characters (three lines at 1230px) following a one-line heading and 108-124 characters (two lines at 1230px) following a two-line heading.',
     backgroundColor: '#d4e7e6',
@@ -44,7 +44,8 @@ export const WithPhotograph: Story = {
   args: {
     ...WithIllustration.args,
     imageIsPhoto: true,
-    image: 'http://files.consumerfinance.gov/f/images/PC_hero.original.jpg',
+    image:
+      'https://cfpb.github.io/design-system/images/uploads/design_system_photo_hero_example.png',
     backgroundColor: '#f7f8f9',
   },
 };
@@ -59,6 +60,6 @@ export const WithKnockoutText: Story = {
     backgroundColor: '#207676',
     isKnockout: true,
     image:
-      'http://files.consumerfinance.gov/f/images/ConsumerMarketTrends-hero.original.png',
+      'https://cfpb.github.io/design-system/images/uploads/design_system_knockout_hero_example.png',
   },
 };

--- a/src/components/Hero/hero.stories.tsx
+++ b/src/components/Hero/hero.stories.tsx
@@ -46,6 +46,8 @@ export const WithPhotograph: Story = {
     imageIsPhoto: true,
     image:
       'https://cfpb.github.io/design-system/images/uploads/design_system_photo_hero_example.png',
+    mobileImage:
+      'https://cfpb.github.io/design-system/images/uploads/design_system_photo_hero_sm_example.jpg',
     backgroundColor: '#f7f8f9',
   },
 };

--- a/src/components/Hero/hero.stories.tsx
+++ b/src/components/Hero/hero.stories.tsx
@@ -59,6 +59,6 @@ export const WithKnockoutText: Story = {
     backgroundColor: '#207676',
     isKnockout: true,
     image:
-      'https://cfpb.github.io/design-system/images/uploads/design_system_hero_example.png',
+      'https://files.consumerfinance.gov/f/images/ConsumerMarketTrends-hero.original.png',
   },
 };

--- a/src/components/Hero/hero.stories.tsx
+++ b/src/components/Hero/hero.stories.tsx
@@ -44,7 +44,7 @@ export const WithPhotograph: Story = {
   args: {
     ...WithIllustration.args,
     imageIsPhoto: true,
-    image: 'https://files.consumerfinance.gov/f/images/PC_hero.original.jpg',
+    image: 'http://files.consumerfinance.gov/f/images/PC_hero.original.jpg',
     backgroundColor: '#f7f8f9',
   },
 };
@@ -59,6 +59,6 @@ export const WithKnockoutText: Story = {
     backgroundColor: '#207676',
     isKnockout: true,
     image:
-      'https://cfpb.github.io/design-system/images/uploads/design_system_hero_example.png',
+      'http://files.consumerfinance.gov/f/images/ConsumerMarketTrends-hero.original.png',
   },
 };

--- a/src/components/Hero/hero.stories.tsx
+++ b/src/components/Hero/hero.stories.tsx
@@ -59,6 +59,6 @@ export const WithKnockoutText: Story = {
     backgroundColor: '#207676',
     isKnockout: true,
     image:
-      'https://files.consumerfinance.gov/f/images/ConsumerMarketTrends-hero.original.png',
+      'https://cfpb.github.io/design-system/images/uploads/design_system_hero_example.png',
   },
 };

--- a/src/components/Hero/hero.test.tsx
+++ b/src/components/Hero/hero.test.tsx
@@ -1,8 +1,9 @@
+import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import Hero from './hero';
 
 describe('Hero', () => {
-  it('Renders all elements: heading, subheading, image', () => {
+  it('renders heading, subheading, and image with DS classes', () => {
     const heading = 'heading';
     const subheading = 'subheading';
     const image = '../../assets/images/credit-card-hero.png';
@@ -17,69 +18,60 @@ describe('Hero', () => {
       />,
     );
 
-    expect(screen.getByText(heading).className).toMatch(/m-hero__heading/g);
-    expect(screen.getByText(subheading).className).toMatch(/m-hero__subhead/g);
-    expect(screen.getByRole('img', { name: imageText }).className).toMatch(
-      /m-hero__image/g,
+    const headingElement = screen.getByRole('heading', { level: 1 });
+    expect(headingElement).toHaveClass('m-hero__heading');
+    expect(headingElement).toHaveTextContent(heading);
+
+    const subheadingElement = screen.getByText(subheading);
+    expect(subheadingElement.tagName).toBe('P');
+    expect(subheadingElement).toHaveClass('m-hero__subhead');
+
+    expect(screen.getByRole('img', { name: imageText })).toHaveClass(
+      'm-hero__image',
     );
   });
 
-  it('Derives CSS classes for component variations', () => {
+  it('derives CSS classes for component variations', () => {
     const isKnockout = 'm-hero--knockout';
     const imageIsPhoto = 'm-hero--overlay';
 
     render(<Hero isKnockout data-testid={isKnockout} />);
-    expect(screen.getByTestId(isKnockout).className).toMatch(isKnockout);
+    expect(screen.getByTestId(isKnockout)).toHaveClass(isKnockout);
 
     render(<Hero imageIsPhoto data-testid={imageIsPhoto} />);
-    expect(screen.getByTestId(imageIsPhoto).className).toMatch(imageIsPhoto);
+    expect(screen.getByTestId(imageIsPhoto)).toHaveClass(imageIsPhoto);
   });
 
-  it('Applies direct color settings', () => {
-    const textColor = 'orange';
-    const backgroundColor = 'purple';
-    const wrapperSelector = 'wrapper';
-    const textId = 'hero-text';
+  it('applies background color on the wrapper for standard heroes', () => {
+    render(
+      <Hero backgroundColor='#800080' heading='test' data-testid='hero' />,
+    );
 
+    expect(screen.getByTestId('hero-wrapper').style.backgroundColor).toBe(
+      'rgb(128, 0, 128)',
+    );
+  });
+
+  it('applies background color on the section for knockout heroes', () => {
     render(
       <Hero
-        data-testid='wrapper'
-        textColor={textColor}
-        backgroundColor={backgroundColor}
+        isKnockout
+        backgroundColor='#207676'
         heading='test'
+        data-testid='hero'
       />,
     );
 
-    // Background color
-    const wrapper = screen.getByTestId(wrapperSelector);
-    expect(wrapper.style.backgroundColor).toMatch(backgroundColor);
-
-    // Text color
-    const text = screen.getByTestId(textId);
-    expect(text.style.color).toMatch(textColor);
+    expect(screen.getByTestId('hero')).toHaveStyle({
+      backgroundColor: '#207676',
+    });
   });
 
-  it('Applies heading levels', () => {
-    const headingLevel = 2;
-    const headingText = 'Heading text';
-    const subheadingLevel = 3;
-    const subheadingText = 'Subheading text';
-
+  it('does not set inline text color (knockout uses DS styles)', () => {
     render(
-      <Hero
-        heading='Heading text'
-        headingLevel={`h${headingLevel}`}
-        subheading='Subheading text'
-        subheadingLevel={`h${subheadingLevel}`}
-      />,
+      <Hero isKnockout heading='test' subheading='sub' data-testid='hero' />,
     );
 
-    // Heading
-    const header = screen.getByRole('heading', { level: headingLevel });
-    expect(header).toHaveProperty('textContent', headingText);
-
-    // Subheading
-    const subheading = screen.getByRole('heading', { level: subheadingLevel });
-    expect(subheading).toHaveProperty('textContent', subheadingText);
+    expect(screen.getByTestId('hero-text')).not.toHaveAttribute('style');
   });
 });

--- a/src/components/Hero/hero.test.tsx
+++ b/src/components/Hero/hero.test.tsx
@@ -42,14 +42,15 @@ describe('Hero', () => {
     expect(screen.getByTestId(imageIsPhoto)).toHaveClass(imageIsPhoto);
   });
 
-  it('applies background color on the wrapper for standard heroes', () => {
+  it('applies background color on the section for standard heroes', () => {
     render(
       <Hero backgroundColor='#800080' heading='test' data-testid='hero' />,
     );
 
-    expect(screen.getByTestId('hero-wrapper').style.backgroundColor).toBe(
-      'rgb(128, 0, 128)',
-    );
+    expect(screen.getByTestId('hero')).toHaveStyle({
+      backgroundColor: 'rgb(128, 0, 128)',
+    });
+    expect(screen.getByTestId('hero-wrapper')).not.toHaveAttribute('style');
   });
 
   it('applies background color on the section for knockout heroes', () => {

--- a/src/components/Hero/hero.test.tsx
+++ b/src/components/Hero/hero.test.tsx
@@ -38,7 +38,13 @@ describe('Hero', () => {
     render(<Hero isKnockout data-testid={isKnockout} />);
     expect(screen.getByTestId(isKnockout)).toHaveClass(isKnockout);
 
-    render(<Hero imageIsPhoto data-testid={imageIsPhoto} />);
+    render(
+      <Hero
+        imageIsPhoto
+        mobileImage='/mobile-photo.jpg'
+        data-testid={imageIsPhoto}
+      />,
+    );
     expect(screen.getByTestId(imageIsPhoto)).toHaveClass(imageIsPhoto);
   });
 
@@ -86,12 +92,16 @@ describe('Hero', () => {
       />,
     );
 
-    expect(screen.getByRole('img', { name: 'photo hero' })).toHaveStyle({
-      backgroundImage: 'url("/mobile-photo.jpg")',
-    });
+    const heroImage = screen.getByRole('img', { name: 'photo hero' });
+    expect(heroImage.style.getPropertyValue('--m-hero-image')).toBe(
+      'url("/desktop-photo.png")',
+    );
+    expect(heroImage.style.getPropertyValue('--m-hero-mobile-image')).toBe(
+      'url("/mobile-photo.jpg")',
+    );
   });
 
-  it('ignores the mobile image in the image slot for non-photo heroes', () => {
+  it('supports a mobile image in the image slot for non-photo heroes', () => {
     render(
       <Hero
         image='/illustration.png'
@@ -100,8 +110,25 @@ describe('Hero', () => {
       />,
     );
 
-    expect(screen.getByRole('img', { name: 'illustration hero' })).toHaveStyle({
-      backgroundImage: 'url("/illustration.png")',
-    });
+    const heroImage = screen.getByRole('img', { name: 'illustration hero' });
+    expect(heroImage.style.getPropertyValue('--m-hero-image')).toBe(
+      'url("/illustration.png")',
+    );
+    expect(heroImage.style.getPropertyValue('--m-hero-mobile-image')).toBe(
+      'url("/mobile-photo.jpg")',
+    );
+  });
+
+  it('requires a mobile image for photo heroes', () => {
+    expect(() =>
+      render(
+        // @ts-expect-error mobileImage is required when imageIsPhoto is true.
+        <Hero
+          imageIsPhoto
+          image='/desktop-photo.png'
+          imageAltText='photo hero'
+        />,
+      ),
+    ).toThrow('Hero requires mobileImage when imageIsPhoto is true.');
   });
 });

--- a/src/components/Hero/hero.test.tsx
+++ b/src/components/Hero/hero.test.tsx
@@ -75,4 +75,33 @@ describe('Hero', () => {
 
     expect(screen.getByTestId('hero-text')).not.toHaveAttribute('style');
   });
+
+  it('uses the mobile image in the image slot for photo heroes', () => {
+    render(
+      <Hero
+        imageIsPhoto
+        image='/desktop-photo.png'
+        mobileImage='/mobile-photo.jpg'
+        imageAltText='photo hero'
+      />,
+    );
+
+    expect(screen.getByRole('img', { name: 'photo hero' })).toHaveStyle({
+      backgroundImage: 'url("/mobile-photo.jpg")',
+    });
+  });
+
+  it('ignores the mobile image in the image slot for non-photo heroes', () => {
+    render(
+      <Hero
+        image='/illustration.png'
+        mobileImage='/mobile-photo.jpg'
+        imageAltText='illustration hero'
+      />,
+    );
+
+    expect(screen.getByRole('img', { name: 'illustration hero' })).toHaveStyle({
+      backgroundImage: 'url("/illustration.png")',
+    });
+  });
 });

--- a/src/components/Hero/hero.tsx
+++ b/src/components/Hero/hero.tsx
@@ -6,11 +6,13 @@ import { HeroImage } from './hero-image';
 import './hero.scss';
 import { useBackgroundImage } from './use-background-image';
 
-export interface HeroProperties
-  extends Omit<HTMLAttributes<HTMLElement>, 'children' | 'color'> {
+export interface HeroProperties extends Omit<
+  HTMLAttributes<HTMLElement>,
+  'children' | 'color'
+> {
   /** CSS background color on `.m-hero` (full bleed). Photo heroes also pass this to the wrapper for overlay image rules. */
   backgroundColor?: string;
-  /** Hero heading copy (DS: 41 chars max for one line at largest breakpoint). */
+  /** Content guidelines for heading: One-line (at largest breakpoint): 41 characters maximum; Two-lines (at largest breakpoint): 82 characters maximum */
   heading?: string;
   /** Illustration or photo URL for `.m-hero__image` / overlay wrapper background. */
   image?: string;
@@ -18,9 +20,9 @@ export interface HeroProperties
   imageAltText?: string;
   /** Photo hero (`m-hero--overlay`): image on the wrapper at tablet+, in the image slot on mobile. */
   imageIsPhoto?: boolean;
-  /** Dark background with light text (`m-hero--knockout`). Text color comes from DS styles. */
+  /** When using a dark background, add the m-hero--knockout to switch the text to white. */
   isKnockout?: boolean;
-  /** Lead copy under the heading (DS character counts vary by heading line count). */
+  /** Content guidelines for subheading: After one-line heading, subheading text can be between 165 and 186 characters (three lines at largest breakpoint); After two-line heading, subheading text can be between 108 and 124 characters (two lines at largest breakpoint) */
   subheading?: string;
 }
 

--- a/src/components/Hero/hero.tsx
+++ b/src/components/Hero/hero.tsx
@@ -27,15 +27,14 @@ interface HeroSharedProperties extends Omit<
 export type HeroProperties = HeroSharedProperties &
   (
     | {
-        /** Photo hero (`m-hero--overlay`): `image` is used on the wrapper at tablet+, `mobileImage` is used in the image slot on mobile. */
+        /** Photo hero (`m-hero--overlay`): Two images must be created, one for large and one for small screens.*/
         imageIsPhoto: true;
         /** Required mobile photo URL for `.m-hero__image` when `imageIsPhoto` is true. */
         mobileImage: string;
       }
     | {
-        /** Standard hero or knockout hero. */
+        // Standard hero or knockout, mobile image optional.
         imageIsPhoto?: false;
-        /** Small-screen image URL for `.m-hero__image`; switches to `image` at tablet+. */
         mobileImage?: string;
       }
   );

--- a/src/components/Hero/hero.tsx
+++ b/src/components/Hero/hero.tsx
@@ -6,7 +6,7 @@ import { HeroImage } from './hero-image';
 import './hero.scss';
 import { useBackgroundImage } from './use-background-image';
 
-export interface HeroProperties extends Omit<
+interface HeroSharedProperties extends Omit<
   HTMLAttributes<HTMLElement>,
   'children' | 'color'
 > {
@@ -18,15 +18,27 @@ export interface HeroProperties extends Omit<
   image?: string;
   /** Accessible name for the decorative hero image. */
   imageAltText?: string;
-  /** Photo hero (`m-hero--overlay`): image on the wrapper at tablet+, in the image slot on mobile. */
-  imageIsPhoto?: boolean;
-  /** Optional mobile photo URL for `.m-hero__image` when `imageIsPhoto` is true. */
-  mobileImage?: string;
   /** When using a dark background, add the m-hero--knockout to switch the text to white. */
   isKnockout?: boolean;
   /** Content guidelines for subheading: After one-line heading, subheading text can be between 165 and 186 characters (three lines at largest breakpoint); After two-line heading, subheading text can be between 108 and 124 characters (two lines at largest breakpoint) */
   subheading?: string;
 }
+
+export type HeroProperties = HeroSharedProperties &
+  (
+    | {
+        /** Photo hero (`m-hero--overlay`): `image` is used on the wrapper at tablet+, `mobileImage` is used in the image slot on mobile. */
+        imageIsPhoto: true;
+        /** Required mobile photo URL for `.m-hero__image` when `imageIsPhoto` is true. */
+        mobileImage: string;
+      }
+    | {
+        /** Standard hero or knockout hero. */
+        imageIsPhoto?: false;
+        /** Small-screen image URL for `.m-hero__image`; switches to `image` at tablet+. */
+        mobileImage?: string;
+      }
+  );
 
 /**
  * CFPB hero pattern (illustration, photograph, knockout).
@@ -55,6 +67,10 @@ export default function Hero({
     imageIsPhoto ? backgroundColor : undefined,
   );
 
+  if (imageIsPhoto && !mobileImage) {
+    throw new Error('Hero requires mobileImage when imageIsPhoto is true.');
+  }
+
   const heroCnames = ['m-hero', className];
 
   if (isKnockout) heroCnames.push('m-hero--knockout');
@@ -63,7 +79,6 @@ export default function Hero({
   // Custom colors belong on `.m-hero` (full width). The wrapper is max-width centered in DS
   // CSS, so a wrapper-only background leaves the section default visible at the sides.
   const heroStyle = backgroundColor ? { backgroundColor } : undefined;
-  const imageSlotSource = imageIsPhoto ? (mobileImage ?? image) : image;
 
   return (
     <section
@@ -92,7 +107,11 @@ export default function Hero({
             </p>
           ) : null}
         </div>
-        <HeroImage image={imageSlotSource} altText={imageAltText} />
+        <HeroImage
+          image={image}
+          mobileImage={mobileImage}
+          altText={imageAltText}
+        />
       </div>
     </section>
   );

--- a/src/components/Hero/hero.tsx
+++ b/src/components/Hero/hero.tsx
@@ -20,6 +20,8 @@ export interface HeroProperties extends Omit<
   imageAltText?: string;
   /** Photo hero (`m-hero--overlay`): image on the wrapper at tablet+, in the image slot on mobile. */
   imageIsPhoto?: boolean;
+  /** Optional mobile photo URL for `.m-hero__image` when `imageIsPhoto` is true. */
+  mobileImage?: string;
   /** When using a dark background, add the m-hero--knockout to switch the text to white. */
   isKnockout?: boolean;
   /** Content guidelines for subheading: After one-line heading, subheading text can be between 165 and 186 characters (three lines at largest breakpoint); After two-line heading, subheading text can be between 108 and 124 characters (two lines at largest breakpoint) */
@@ -41,6 +43,7 @@ export default function Hero({
   image,
   imageAltText = 'hero image',
   imageIsPhoto,
+  mobileImage,
   isKnockout,
   subheading,
   className,
@@ -60,6 +63,7 @@ export default function Hero({
   // Custom colors belong on `.m-hero` (full width). The wrapper is max-width centered in DS
   // CSS, so a wrapper-only background leaves the section default visible at the sides.
   const heroStyle = backgroundColor ? { backgroundColor } : undefined;
+  const imageSlotSource = imageIsPhoto ? (mobileImage ?? image) : image;
 
   return (
     <section
@@ -88,7 +92,7 @@ export default function Hero({
             </p>
           ) : null}
         </div>
-        <HeroImage image={image} altText={imageAltText} />
+        <HeroImage image={imageSlotSource} altText={imageAltText} />
       </div>
     </section>
   );

--- a/src/components/Hero/hero.tsx
+++ b/src/components/Hero/hero.tsx
@@ -8,7 +8,7 @@ import { useBackgroundImage } from './use-background-image';
 
 export interface HeroProperties
   extends Omit<HTMLAttributes<HTMLElement>, 'children' | 'color'> {
-  /** CSS background color (wrapper for standard heroes; section for knockout). */
+  /** CSS background color on `.m-hero` (full bleed). Photo heroes also pass this to the wrapper for overlay image rules. */
   backgroundColor?: string;
   /** Hero heading copy (DS: 41 chars max for one line at largest breakpoint). */
   heading?: string;
@@ -44,12 +44,10 @@ export default function Hero({
   className,
   ...properties
 }: HeroProperties): JSX.Element {
-  const wrapperBackgroundColor = isKnockout ? undefined : backgroundColor;
-
   const wrapperReference = useBackgroundImage(
     image,
     Boolean(imageIsPhoto),
-    wrapperBackgroundColor,
+    imageIsPhoto ? backgroundColor : undefined,
   );
 
   const heroCnames = ['m-hero', className];
@@ -57,14 +55,9 @@ export default function Hero({
   if (isKnockout) heroCnames.push('m-hero--knockout');
   if (imageIsPhoto) heroCnames.push('m-hero--overlay');
 
-  const heroStyle =
-    isKnockout && backgroundColor ? { backgroundColor } : undefined;
-
-  const usesWrapperBackgroundColor =
-    Boolean(wrapperBackgroundColor) && !imageIsPhoto;
-  const wrapperStyle = usesWrapperBackgroundColor
-    ? { backgroundColor: wrapperBackgroundColor }
-    : undefined;
+  // Custom colors belong on `.m-hero` (full width). The wrapper is max-width centered in DS
+  // CSS, so a wrapper-only background leaves the section default visible at the sides.
+  const heroStyle = backgroundColor ? { backgroundColor } : undefined;
 
   return (
     <section
@@ -76,7 +69,6 @@ export default function Hero({
         className='m-hero__wrapper'
         data-testid='hero-wrapper'
         ref={wrapperReference}
-        style={wrapperStyle}
       >
         <div className='m-hero__text' data-testid='hero-text'>
           {heading ? (

--- a/src/components/Hero/hero.tsx
+++ b/src/components/Hero/hero.tsx
@@ -1,102 +1,101 @@
 import classnames from 'classnames';
 import { JSX } from 'react';
-import type { HTMLAttributes, ReactNode } from 'react';
-import type { HeadingLevel } from '../../types/heading-level';
-import type { HeadingType } from '../Headings/heading';
+import type { HTMLAttributes } from 'react';
 import { Heading } from '../Headings/heading';
 import { HeroImage } from './hero-image';
 import './hero.scss';
 import { useBackgroundImage } from './use-background-image';
 
-interface HeroProperties extends HTMLAttributes<HTMLDivElement> {
+export interface HeroProperties
+  extends Omit<HTMLAttributes<HTMLElement>, 'children' | 'color'> {
+  /** CSS background color (wrapper for standard heroes; section for knockout). */
   backgroundColor?: string;
-  heading?: ReactNode;
-  headingLevel?: HeadingLevel;
+  /** Hero heading copy (DS: 41 chars max for one line at largest breakpoint). */
+  heading?: string;
+  /** Illustration or photo URL for `.m-hero__image` / overlay wrapper background. */
   image?: string;
+  /** Accessible name for the decorative hero image. */
   imageAltText?: string;
+  /** Photo hero (`m-hero--overlay`): image on the wrapper at tablet+, in the image slot on mobile. */
   imageIsPhoto?: boolean;
+  /** Dark background with light text (`m-hero--knockout`). Text color comes from DS styles. */
   isKnockout?: boolean;
-  subheading?: ReactNode;
-  subheadingLevel?: HeadingLevel | 'p';
-  textColor?: string;
+  /** Lead copy under the heading (DS character counts vary by heading line count). */
+  subheading?: string;
 }
 
 /**
+ * CFPB hero pattern (illustration, photograph, knockout).
+ *
+ * Jumbo and 50/50 variants are not included — see
  * https://cfpb.github.io/design-system/patterns/heroes
  *
- * The Jumbo and 50/50 hero variants, included in the CFPB Design System,
- * and used on the CF.gov homepage are not included by this component.
- *
- * The implementation of the hero on https://www.consumerfinance.gov/es/
- * uses a combination of Jumbo and 50/50 hero variants including some tweaks in
- * wagtail.
+ * Heading uses DS `Heading` type 1 with `m-hero__heading`; subheading is `p.m-hero__subhead`.
+ * Responsive type sizes are handled by DS CSS, not by configurable heading levels.
  */
 export default function Hero({
   backgroundColor,
   heading,
-  headingLevel = 'h1',
   image,
   imageAltText = 'hero image',
   imageIsPhoto,
   isKnockout,
   subheading,
-  subheadingLevel = 'p',
-  textColor,
   className,
   ...properties
 }: HeroProperties): JSX.Element {
-  const wrapperReference = useBackgroundImage(image, Boolean(imageIsPhoto));
+  const wrapperBackgroundColor = isKnockout ? undefined : backgroundColor;
 
-  const heroStyles = { backgroundColor };
-  const textStyles = { color: textColor };
+  const wrapperReference = useBackgroundImage(
+    image,
+    Boolean(imageIsPhoto),
+    wrapperBackgroundColor,
+  );
+
   const heroCnames = ['m-hero', className];
 
   if (isKnockout) heroCnames.push('m-hero--knockout');
   if (imageIsPhoto) heroCnames.push('m-hero--overlay');
 
-  // NOTE: This is a mapping of the Hero component's HeadingLevel to the Heading component's
-  // HeadingType but we could also use the HeadingType directly in the Hero component with some
-  // refactoring of the Heading component or run a regex replace on the HeadingLevel in the Hero
-  const HeadingLevelToHeadingType: Record<string, HeadingType> = {
-    h1: '1',
-    h2: '2',
-    h3: '3',
-    h4: '4',
-    h5: '5',
-    display: 'display',
-    eyebrow: 'eyebrow',
-    slug: 'slug',
-  };
+  const heroStyle =
+    isKnockout && backgroundColor ? { backgroundColor } : undefined;
+
+  const usesWrapperBackgroundColor =
+    Boolean(wrapperBackgroundColor) && !imageIsPhoto;
+  const wrapperStyle = usesWrapperBackgroundColor
+    ? { backgroundColor: wrapperBackgroundColor }
+    : undefined;
 
   return (
-    <div className={classnames(heroCnames)} style={heroStyles} {...properties}>
-      <div className='m-hero__wrapper' ref={wrapperReference}>
-        <div
-          className='m-hero__text'
-          style={textStyles}
-          data-testid='hero-text'
-        >
-          <Heading
-            className='m-hero__heading'
-            data-testid='hero-heading'
-            type={HeadingLevelToHeadingType[headingLevel]}
-          >
-            {heading}
-          </Heading>
-          {subheadingLevel === 'p' ? (
-            <p className='m-hero__subhead'>{subheading}</p>
-          ) : (
+    <section
+      className={classnames(heroCnames)}
+      style={heroStyle}
+      {...properties}
+    >
+      <div
+        className='m-hero__wrapper'
+        data-testid='hero-wrapper'
+        ref={wrapperReference}
+        style={wrapperStyle}
+      >
+        <div className='m-hero__text' data-testid='hero-text'>
+          {heading ? (
             <Heading
-              className='m-hero__subhead'
-              data-testid='hero-subheading'
-              type={HeadingLevelToHeadingType[subheadingLevel]}
+              className='m-hero__heading'
+              data-testid='hero-heading'
+              type='1'
             >
-              {subheading}
+              {heading}
             </Heading>
-          )}
+          ) : null}
+          {subheading ? (
+            <p className='m-hero__subhead' data-testid='hero-subheading'>
+              {subheading}
+            </p>
+          ) : null}
         </div>
         <HeroImage image={image} altText={imageAltText} />
       </div>
-    </div>
+    </section>
   );
 }

--- a/src/components/Hero/use-background-image.tsx
+++ b/src/components/Hero/use-background-image.tsx
@@ -23,23 +23,18 @@ export const useBackgroundImage = (
 
     if (!shouldAddPhotoBackground || !image) {
       element.style.removeProperty('background-image');
+      element.style.removeProperty('--m-hero-wrapper-image');
       return;
     }
 
-    const url = JSON.stringify(image);
-    const colorRule = backgroundColor
-      ? `background-color: ${backgroundColor};`
-      : '';
-    element.style.cssText = `${colorRule}
-      background-image: url(${url});
-      background-image: -webkit-image-set(
-        url(${url}) 1x,
-        url(${url}) 2x
-      );
-      background-image: image-set(
-        url(${url}) 1x,
-        url(${url}) 2x
-      );`;
+    const url = `url(${JSON.stringify(image)})`;
+    element.style.setProperty('--m-hero-wrapper-image', url);
+
+    if (backgroundColor) {
+      element.style.backgroundColor = backgroundColor;
+    } else {
+      element.style.removeProperty('background-color');
+    }
   }, [image, shouldAddPhotoBackground, backgroundColor]);
 
   return imageWrapperReference;

--- a/src/components/Hero/use-background-image.tsx
+++ b/src/components/Hero/use-background-image.tsx
@@ -2,37 +2,45 @@ import type { Ref } from 'react';
 import { useEffect, useRef } from 'react';
 
 /**
- * Add inline styles which apply a background-image to the referenced <div>
+ * Applies photograph hero background-image rules to `.m-hero__wrapper` per the DS.
+ * Only runs for `m-hero--overlay`; does not clear other inline styles (e.g. backgroundColor).
  *
  * @param image Image URL
- * @param shoudAddStyles Flag to indicate that inline styles should be included
- * @returns Ref that should be attached to the wrapper <div>
+ * @param shouldAddPhotoBackground When true, set wrapper background-image (tablet+)
+ * @param backgroundColor Optional wrapper background color to preserve with photo styles
+ * @returns Ref that should be attached to the wrapper `<div>`
  */
 export const useBackgroundImage = (
   image?: string,
-  shoudAddStyles?: boolean,
+  shouldAddPhotoBackground?: boolean,
+  backgroundColor?: string,
 ): Ref<HTMLDivElement> => {
   const imageWrapperReference = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (!shoudAddStyles || !image || !imageWrapperReference.current) {
-      imageWrapperReference.current?.setAttribute('style', '');
+    const element = imageWrapperReference.current;
+    if (!element) return;
+
+    if (!shouldAddPhotoBackground || !image) {
+      element.style.removeProperty('background-image');
       return;
     }
 
-    imageWrapperReference.current.setAttribute(
-      'style',
-      `background-image: url(${image});
-       background-image: -webkit-image-set(
-        url(${image}) 1x,
-        url(${image}) 2x
+    const url = JSON.stringify(image);
+    const colorRule = backgroundColor
+      ? `background-color: ${backgroundColor};`
+      : '';
+    element.style.cssText = `${colorRule}
+      background-image: url(${url});
+      background-image: -webkit-image-set(
+        url(${url}) 1x,
+        url(${url}) 2x
       );
       background-image: image-set(
-        url(${image}) 1x,
-        url(${image}) 2x
-      );`,
-    );
-  }, [imageWrapperReference, image, shoudAddStyles]);
+        url(${url}) 1x,
+        url(${url}) 2x
+      );`;
+  }, [image, shouldAddPhotoBackground, backgroundColor]);
 
   return imageWrapperReference;
 };


### PR DESCRIPTION
Addresses: #596 

Hero work:
- aligned with cfpb heroes pattern docs
- dropped headingLevel subheadingLevel textColor props
- heading and subheading typed as strings
- use DSR Heading type 1 with m-hero__heading not raw h1
- subheading still p.m-hero__subhead
- root is section not div
- backgroundColor on wrapper normally, on section for knockout
- fixed useBackgroundImage clearing wrapper backgroundColor
- HeroProperties omits children and color from html attrs
- only render heading/subheading when provided
- Added mobileImage option for photograph heroes
- updated stories to point to images from DS github page
