### PR TITLE
Search input BEM validation

### DIFF
--- a/src/components/TextInput/text-area.test.tsx
+++ b/src/components/TextInput/text-area.test.tsx
@@ -27,7 +27,7 @@ describe('<TextArea />', () => {
     render(<TextArea id='alert' isFullWidth />);
 
     const textInput = screen.getByTestId('textAreaInput');
-    expect(textInput).toHaveClass('a-text-input__full');
+    expect(textInput).toHaveClass('a-text-input--full');
   });
 
   it('Handles all supported statuses', () => {

--- a/src/components/TextInput/text-area.tsx
+++ b/src/components/TextInput/text-area.tsx
@@ -48,7 +48,7 @@ export const TextArea = forwardRef(
     const classes = [
       'a-text-input',
       getTextInputStatusClass(status),
-      isFullWidth ? 'a-text-input__full' : '',
+      isFullWidth ? 'a-text-input--full' : '',
       className || '',
     ].filter((x) => x.length);
 

--- a/src/components/TextInput/text-input.stories.tsx
+++ b/src/components/TextInput/text-input.stories.tsx
@@ -114,8 +114,6 @@ export const SearchInput: Story = {
     name: 'SearchInput',
     id: 'SearchInput',
     type: 'search',
-    isFullWidth: false,
-    className: 'a-text-input__full',
   },
   render: (args) => {
     const { value: initialValue, ...restArgs } = args as TextInputProperties & {

--- a/src/components/TextInput/text-input.test.tsx
+++ b/src/components/TextInput/text-input.test.tsx
@@ -43,6 +43,6 @@ describe('<TextInput />', () => {
     render(<TextInput id='alert' name='alert' type='number' isFullWidth />);
 
     const textInput = screen.getByTestId('textInput');
-    expect(textInput).toHaveClass('a-text-input__full');
+    expect(textInput).toHaveClass('a-text-input--full');
   });
 });

--- a/src/components/TextInput/text-input.tsx
+++ b/src/components/TextInput/text-input.tsx
@@ -64,7 +64,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProperties>(
     ];
 
     if (isFullWidth) {
-      classes.push('a-text-input__full');
+      classes.push('a-text-input--full');
       return (
         <div className='m-form-field'>
           <input


### PR DESCRIPTION
Addresses https://github.com/cfpb/design-system-react/issues/390

This is similar to https://github.com/cfpb/design-system-react/pull/602
This is similar to https://github.com/cfpb/design-system-react/pull/603

Question for @anselmbradford:

I noticed some inconsistencies with how `a-text-input__full` class is being used or not used in the search component

should it be `a-text-input--full` ?

https://cfpb.github.io/design-system/components/text-inputs

The DS documentation lists __full, but i've seen `a-text-input--full` as well as `a-text-input__full`.  

I don't see any rules for __full

