### PR TITLE
Header adjustment

### DIFF
--- a/src/components/Header/header.stories.tsx
+++ b/src/components/Header/header.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Button, Header } from '~/src/index';
+import { Header } from '~/src/index';
 import { ExampleLinks } from './responsive-menu';
-import Link from '../Link/link';
 
 const meta: Meta<typeof Header> = {
   title: 'Components (Draft)/Headers',
@@ -38,34 +37,3 @@ export const Basic: Story = {
     links: [],
   },
 };
-
-export const LinksWithIcon: Story = {
-  render: (properties) => <Header {...properties} />,
-  args: {
-    links: [
-      <Link key='home' href='/' label='Home' />,
-      <Link
-        key='filing'
-        className='nav-item'
-        href='/filing'
-        label='Filing'
-      />,
-      <Link
-        key='profile'
-        className='nav-item'
-        href='/profile'
-        label='User guide'
-        iconRight='document'
-      />,
-      <Button
-        appearance={'secondary'}
-        label='Log out'
-        onClick={(): void => {
-          /* Empty*/
-        }}
-        key='logout'
-      />,
-    ],
-  },
-};
-

--- a/src/components/Header/header.stories.tsx
+++ b/src/components/Header/header.stories.tsx
@@ -2,7 +2,6 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Button, Header } from '~/src/index';
 import { ExampleLinks } from './responsive-menu';
 import Link from '../Link/link';
-import React from 'react';
 
 const meta: Meta<typeof Header> = {
   title: 'Components (Draft)/Headers',

--- a/src/components/Header/header.stories.tsx
+++ b/src/components/Header/header.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Header } from '~/src/index';
+import { Button, Header } from '~/src/index';
 import { ExampleLinks } from './responsive-menu';
+import Link from '../Link/link';
+import React from 'react';
 
 const meta: Meta<typeof Header> = {
   title: 'Components (Draft)/Headers',
@@ -37,3 +39,34 @@ export const Basic: Story = {
     links: [],
   },
 };
+
+export const LinksWithIcon: Story = {
+  render: (properties) => <Header {...properties} />,
+  args: {
+    links: [
+      <Link key='home' href='/' label='Home' />,
+      <Link
+        key='filing'
+        className='nav-item'
+        href='/filing'
+        label='Filing'
+      />,
+      <Link
+        key='profile'
+        className='nav-item'
+        href='/profile'
+        label='User guide'
+        iconRight='document'
+      />,
+      <Button
+        appearance={'secondary'}
+        label='Log out'
+        onClick={(): void => {
+          /* Empty*/
+        }}
+        key='logout'
+      />,
+    ],
+  },
+};
+

--- a/src/components/Header/responsive-menu.scss
+++ b/src/components/Header/responsive-menu.scss
@@ -153,10 +153,14 @@ $max-width: $bp-sm-max;
             margin-right: 0;
             padding: 10px 0;
             text-align: left;
+            // no underline when in menu
+            .a-link__text {
+              text-decoration: none;
+            }
 
             @media (min-width: $breakpoint) {
               border-bottom: 1px dotted transparent;
-              margin-right: $space-xl;
+              margin-right: $space-lg;
               padding: 0;
             }
 

--- a/src/components/Header/responsive-menu.scss
+++ b/src/components/Header/responsive-menu.scss
@@ -66,6 +66,7 @@ $max-width: $bp-sm-max;
       .menu-toggle {
         border: none;
         background-color: transparent;
+        color: var(--text);
         cursor: pointer;
         align-self: stretch;
         width: 54px;

--- a/src/components/Header/responsive-menu.test.tsx
+++ b/src/components/Header/responsive-menu.test.tsx
@@ -48,10 +48,8 @@ describe('ResponsiveMenu', () => {
     expect(screen.getByRole('navigation')).toBeInTheDocument();
 
     // Links are rendered
-    expect(screen.getByText('Home')).toBeInTheDocument();
-    expect(screen.getByText('Filing')).toBeInTheDocument();
-    expect(screen.getByText('John Sample')).toBeInTheDocument();
-    expect(screen.getByText('Log out')).toBeInTheDocument();
+    expect(screen.getAllByRole('link', { name: 'Link' })).toHaveLength(3);
+    expect(screen.getByRole('button', { name: 'Log out' })).toBeInTheDocument();
   });
 
   it('toggles menu visibility on button click', () => {
@@ -92,7 +90,7 @@ describe('ResponsiveMenu', () => {
     const menuToggle = screen.getAllByRole('button')[0];
     fireEvent.click(menuToggle);
 
-    const link = screen.getByText('Home');
+    const link = screen.getAllByRole('link', { name: 'Link' })[0];
     fireEvent.click(link);
 
     expect(screen.getByRole('navigation')).not.toHaveClass('open');
@@ -101,7 +99,7 @@ describe('ResponsiveMenu', () => {
   it('applies active class to the current page link', () => {
     renderWithScope(<ResponsiveMenu links={ExampleLinks} />);
 
-    const activeLink = screen.getByText('Filing');
+    const activeLink = screen.getAllByRole('link', { name: 'Link' })[1];
     expect(activeLink).toHaveClass('active');
   });
 

--- a/src/components/Header/responsive-menu.tsx
+++ b/src/components/Header/responsive-menu.tsx
@@ -145,19 +145,9 @@ export default function ResponsiveMenu({
 }
 
 export const ExampleLinks: ReactNode[] = [
-  <Link key='home' href='/' label='Home' />,
-  <Link
-    key='filing'
-    className='nav-item active'
-    href='/filing'
-    label='Filing'
-  />,
-  <Link
-    key='profile'
-    className='nav-item profile'
-    href='/profile'
-    label='John Sample'
-  />,
+  <Link key='1' href='/' label='Link' />,
+  <Link key='2' className='nav-item active' href='/2' label='Link' />,
+  <Link key='3' className='nav-item' href='/3' label='Link' />,
   <Button
     appearance={'secondary'}
     label='Log out'


### PR DESCRIPTION
- Removes the underline in links with icon
- Adjusts right margin to 45 px instead of 60px
- Adds storybook example
<img width="978" height="180" alt="Screenshot 2026-06-12 at 4 23 02 PM" src="https://github.com/user-attachments/assets/e39328bd-ecea-4b62-8886-10d18308b69d" />


See example:
https://cfpb.github.io/design-system-react/pr-previews/pr-611/?path=/docs/components-draft-headers--overview