### PR TITLE
Remove local wrapper width override

### DIFF
--- a/src/assets/styles/_shared.scss
+++ b/src/assets/styles/_shared.scss
@@ -85,10 +85,3 @@ body,
     line-height: 22px !important;
   }
 }
-
-// Override DS wrapper match-content width to 1170px content with 30px gutters.
-.wrapper--match-content {
-  @include respond-to-min($bp-sm-min) {
-    max-width: $grid-wrapper-width - ($grid-gutter-width * 2) !important;
-  }
-}


### PR DESCRIPTION
This drops the DSR-specific wrapper--match-content max-width override in src/assets/styles/_shared.scss and lets the width come directly from the Design System package.

That keeps wrapper behavior aligned with DS expectations and avoids narrowing the content width in DSR.

Closes #566.