### PR TITLE
Restrict TextArea resizing to vertical only

### DIFF
--- a/src/components/TextInput/text-area.test.tsx
+++ b/src/components/TextInput/text-area.test.tsx
@@ -47,4 +47,11 @@ describe('<TextArea />', () => {
     expect(textInput).toHaveClass('a-text-input');
     expect(textInput).not.toHaveClass('a-text-input--success');
   });
+
+  it('restricts resizing to the vertical axis', () => {
+    render(<TextArea id='enabled' />);
+
+    const textArea = screen.getByTestId('textAreaInput');
+    expect(textArea).toHaveStyle({ resize: 'vertical' });
+  });
 });

--- a/src/components/TextInput/text-area.tsx
+++ b/src/components/TextInput/text-area.tsx
@@ -38,6 +38,8 @@ export const TextArea = forwardRef(
     }: JSX.IntrinsicElements['textarea'] & TextAreaType,
     reference: Ref<HTMLTextAreaElement>,
   ): ReactElement => {
+    const { style, ...restProperties } = properties;
+
     const onChangeHandler: ChangeEventHandler<HTMLTextAreaElement> = (
       event,
     ) => {
@@ -62,7 +64,8 @@ export const TextArea = forwardRef(
           disabled={isDisabled}
           data-testid='textAreaInput'
           ref={reference}
-          {...properties}
+          style={{ ...style, resize: 'vertical' }}
+          {...restProperties}
         />
       </div>
     );


### PR DESCRIPTION
TextArea currently allows horizontal dragging, which can overflow form layouts on smaller widths.

This sets the textarea resize style to vertical by default while still preserving any other inline styles passed by consumers. I also added a regression test to lock that behavior in.

Tested locally with:
- npx -y @yarnpkg/cli-dist@4.16.0 eslint src/components/TextInput/text-area.tsx src/components/TextInput/text-area.test.tsx
- npx -y @yarnpkg/cli-dist@4.16.0 vitest run src/components/TextInput/text-area.test.tsx
- npx -y @yarnpkg/cli-dist@4.16.0 build

Fixes #315