### PR TITLE
Invert tab backgrounds

### DIFF
--- a/src/components/select/select-multi.tsx
+++ b/src/components/select/select-multi.tsx
@@ -1,8 +1,3 @@
-// Lots of rules disabled because we're using DS code that is plain JS, not TS
-/* eslint-disable @typescript-eslint/no-unsafe-return */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { Multiselect } from '@cfpb/cfpb-design-system/src/components/cfpb-forms';
 import { JSX, useEffect, useRef, useState } from 'react';
 import { noOp } from '../../utils/no-op';

--- a/src/components/tabs/tab.scss
+++ b/src/components/tabs/tab.scss
@@ -21,8 +21,10 @@
       outline: none;
     }
 
+    // Keep the focus ring outside the tab border so overlapping neighbor
+    // borders (same issue as footer links at mobile width) don’t clip it.
     &:focus-visible {
-      outline-offset: -1px;
+      outline-offset: 2px;
     }
 
     &--active {

--- a/src/components/tabs/tab.scss
+++ b/src/components/tabs/tab.scss
@@ -34,6 +34,17 @@
       border-bottom-color: transparent;
     }
   }
+
+  // Background-only invert: inactive keep default link styles.
+  &--inverted {
+    button.tab {
+      background: var(--gray-5);
+
+      &--active {
+        background: var(--white);
+      }
+    }
+  }
 }
 
 .tab-panel {

--- a/src/components/tabs/tab.scss
+++ b/src/components/tabs/tab.scss
@@ -37,13 +37,17 @@
 
   // Like default tabs, but with no tab fills. Mask the tablist rule under the
   // active tab so it still opens into the panel without a bottom border.
+  // Use background-color + !important so DS `.a-btn` / default `.tab--active`
+  // fills cannot win on equal specificity in app bundles.
   &--inverted {
     button.tab {
-      background: transparent;
+      background-color: transparent !important;
+      background-image: none !important;
 
       &--active {
         position: relative;
-        background: transparent;
+        background-color: transparent !important;
+        background-image: none !important;
 
         &::after {
           content: '';

--- a/src/components/tabs/tab.scss
+++ b/src/components/tabs/tab.scss
@@ -35,13 +35,24 @@
     }
   }
 
-  // Like default tabs, but with no tab fills.
+  // Like default tabs, but with no tab fills. Mask the tablist rule under the
+  // active tab so it still opens into the panel without a bottom border.
   &--inverted {
     button.tab {
       background: transparent;
 
       &--active {
+        position: relative;
         background: transparent;
+
+        &::after {
+          content: '';
+          position: absolute;
+          inset-inline: 0;
+          bottom: -1px;
+          height: 1px;
+          background: var(--white);
+        }
       }
     }
   }

--- a/src/components/tabs/tab.scss
+++ b/src/components/tabs/tab.scss
@@ -4,18 +4,26 @@
 
 .tablist {
   display: flex;
-  border-bottom: 1px solid var(--gray-40);
-
-  // margin-bottom: -1px;
-  // position: relative;
-  // z-index: 10;
+  // Inset shadow sits in the background layer so an opaque active tab can cover
+  // it. A real `border-bottom` paints above overlapping children and leaves a
+  // hairline under the active tab (especially with subpixel heights / retina).
+  box-shadow: inset 0 -1px 0 0 var(--gray-40);
 
   button.tab {
     @include heading-4($has-margin-bottom: false);
+    position: relative;
+    z-index: 1;
     padding: math.div(math.div($grid-gutter-width, 3), $base-font-size-px) + rem
       math.div($grid-gutter-width, $base-font-size-px) + rem;
-    margin-bottom: -1px;
     border: 1px solid transparent;
+    // `heading-4` still sets margin-bottom at the xs breakpoint even when
+    // `$has-margin-bottom` is false. That gap leaves the tablist rule hanging
+    // below the tab fills (especially obvious on phone widths).
+    margin-bottom: 0;
+
+    @include respond-to-max($bp-xs-max) {
+      margin-bottom: 0;
+    }
 
     &:focus:not(:focus-visible) {
       outline: none;
@@ -28,7 +36,6 @@
     }
 
     &--active {
-      position: relative;
       color: var(--black);
       // Beat `.a-btn--link { background-color: transparent !important }` so the
       // active fill can cover the tablist rule.
@@ -37,23 +44,12 @@
       text-decoration: none;
       pointer-events: none;
       border-color: var(--gray-40);
-      border-bottom-color: transparent;
-
-      // Mask the tablist rule under the active tab. 2px tall so retina/mobile
-      // subpixel rounding cannot leave a hairline.
-      &::after {
-        content: '';
-        position: absolute;
-        inset-inline: 0;
-        bottom: -1px;
-        height: 2px;
-        background-color: var(--gray-5);
-      }
+      border-bottom-color: var(--gray-5);
     }
   }
 
-  // Like default tabs, but with no tab fills. Mask the tablist rule under the
-  // active tab so it still opens into the panel without a bottom border.
+  // Like default tabs, but with no inactive fills. Active tab uses an opaque
+  // page-colored fill so the tablist rule cannot show through underneath.
   // Use background-color + !important so DS `.a-btn` / default `.tab--active`
   // fills cannot win on equal specificity in app bundles.
   &--inverted {
@@ -62,12 +58,9 @@
       background-image: none !important;
 
       &--active {
-        background-color: transparent !important;
+        background-color: var(--white) !important;
         background-image: none !important;
-
-        &::after {
-          background-color: var(--white);
-        }
+        border-bottom-color: var(--white);
       }
     }
   }

--- a/src/components/tabs/tab.scss
+++ b/src/components/tabs/tab.scss
@@ -26,12 +26,27 @@
     }
 
     &--active {
+      position: relative;
       color: var(--black);
-      background: var(--gray-5);
+      // Beat `.a-btn--link { background-color: transparent !important }` so the
+      // active fill can cover the tablist rule.
+      background-color: var(--gray-5) !important;
+      background-image: none !important;
       text-decoration: none;
       pointer-events: none;
       border-color: var(--gray-40);
       border-bottom-color: transparent;
+
+      // Mask the tablist rule under the active tab. 2px tall so retina/mobile
+      // subpixel rounding cannot leave a hairline.
+      &::after {
+        content: '';
+        position: absolute;
+        inset-inline: 0;
+        bottom: -1px;
+        height: 2px;
+        background-color: var(--gray-5);
+      }
     }
   }
 
@@ -45,17 +60,11 @@
       background-image: none !important;
 
       &--active {
-        position: relative;
         background-color: transparent !important;
         background-image: none !important;
 
         &::after {
-          content: '';
-          position: absolute;
-          inset-inline: 0;
-          bottom: -1px;
-          height: 1px;
-          background: var(--white);
+          background-color: var(--white);
         }
       }
     }

--- a/src/components/tabs/tab.scss
+++ b/src/components/tabs/tab.scss
@@ -35,13 +35,15 @@
     }
   }
 
-  // Background-only invert: inactive keep default link styles.
+  // Invert fills; inactive keep default link styles but show a full border.
   &--inverted {
     button.tab {
       background: var(--gray-5);
+      border-color: var(--gray-40);
 
       &--active {
         background: var(--white);
+        border-bottom-color: transparent;
       }
     }
   }

--- a/src/components/tabs/tab.scss
+++ b/src/components/tabs/tab.scss
@@ -47,6 +47,14 @@
         margin-left: 0;
       }
 
+      // Raise focused tab above neighbors and keep the outline outside the
+      // shared border so the ring isn’t clipped or drawn on top of gray-40.
+      &:focus-visible {
+        position: relative;
+        z-index: 2;
+        outline-offset: 2px;
+      }
+
       &--active {
         position: relative;
         z-index: 1;

--- a/src/components/tabs/tab.scss
+++ b/src/components/tabs/tab.scss
@@ -36,12 +36,20 @@
   }
 
   // Invert fills; inactive keep default link styles but show a full border.
+  // Overlap adjacent borders so neighbors share a single 1px divider.
   &--inverted {
     button.tab {
       background: var(--gray-5);
       border-color: var(--gray-40);
+      margin-left: -1px;
+
+      &:first-child {
+        margin-left: 0;
+      }
 
       &--active {
+        position: relative;
+        z-index: 1;
         background: var(--white);
         border-bottom-color: transparent;
       }

--- a/src/components/tabs/tab.scss
+++ b/src/components/tabs/tab.scss
@@ -35,31 +35,13 @@
     }
   }
 
-  // Invert fills; inactive keep default link styles but show a full border.
-  // Overlap adjacent borders so neighbors share a single 1px divider.
+  // Like default tabs, but with no tab fills.
   &--inverted {
     button.tab {
-      background: var(--gray-5);
-      border-color: var(--gray-40);
-      margin-left: -1px;
-
-      &:first-child {
-        margin-left: 0;
-      }
-
-      // Raise focused tab above neighbors and keep the outline outside the
-      // shared border so the ring isn’t clipped or drawn on top of gray-40.
-      &:focus-visible {
-        position: relative;
-        z-index: 2;
-        outline-offset: 2px;
-      }
+      background: transparent;
 
       &--active {
-        position: relative;
-        z-index: 1;
-        background: var(--white);
-        border-bottom-color: transparent;
+        background: transparent;
       }
     }
   }

--- a/src/components/tabs/tab.stories.tsx
+++ b/src/components/tabs/tab.stories.tsx
@@ -14,45 +14,52 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+const TabsDemo = ({ isInverted = false }: { isInverted?: boolean }) => {
+  const [activeTab, setActiveTab] = useState('one');
+  const onClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setActiveTab(event.currentTarget.value);
+  };
+  return (
+    <>
+      <TabList isInverted={isInverted}>
+        <Tab
+          id='one'
+          value='one'
+          isActive={activeTab === 'one'}
+          iconLeft='list'
+          label='Tab one'
+          onClick={onClick}
+        />
+        <Tab
+          id='two'
+          value='two'
+          isActive={activeTab === 'two'}
+          iconLeft='chart'
+          label='Tab two'
+          onClick={onClick}
+        />
+        <Tab
+          id='three'
+          value='three'
+          isActive={activeTab === 'three'}
+          iconLeft='map'
+          label='Tab three'
+          onClick={onClick}
+        />
+      </TabList>
+      <TabPanel id={activeTab} style={{ padding: '30px' }}>
+        <Heading type='4'>Panel {activeTab}</Heading>
+      </TabPanel>
+    </>
+  );
+};
+
 export const Default: Story = {
   name: 'Tabs',
-  render: () => {
-    const [activeTab, setActiveTab] = useState('one');
-    const onClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-      setActiveTab(event.currentTarget.value);
-    };
-    return (
-      <>
-        <TabList>
-          <Tab
-            id='one'
-            value='one'
-            isActive={activeTab === 'one'}
-            iconLeft='list'
-            label='Tab one'
-            onClick={onClick}
-          />
-          <Tab
-            id='two'
-            value='two'
-            isActive={activeTab === 'two'}
-            iconLeft='chart'
-            label='Tab two'
-            onClick={onClick}
-          />
-          <Tab
-            id='three'
-            value='three'
-            isActive={activeTab === 'three'}
-            iconLeft='map'
-            label='Tab three'
-            onClick={onClick}
-          />
-        </TabList>
-        <TabPanel id={activeTab} style={{ padding: '30px' }}>
-          <Heading type='4'>Panel {activeTab}</Heading>
-        </TabPanel>
-      </>
-    );
-  },
+  render: () => <TabsDemo />,
+};
+
+export const Inverted: Story = {
+  name: 'Tabs (inverted backgrounds)',
+  render: () => <TabsDemo isInverted />,
 };

--- a/src/components/tabs/tab.stories.tsx
+++ b/src/components/tabs/tab.stories.tsx
@@ -60,6 +60,6 @@ export const Default: Story = {
 };
 
 export const Inverted: Story = {
-  name: 'Tabs (inverted backgrounds)',
+  name: 'Tabs (no background)',
   render: () => <TabsDemo isInverted />,
 };

--- a/src/components/tabs/tab.stories.tsx
+++ b/src/components/tabs/tab.stories.tsx
@@ -60,6 +60,6 @@ export const Default: Story = {
 };
 
 export const Inverted: Story = {
-  name: 'Tabs (no background)',
+  name: 'Tabs (inverted backgrounds)',
   render: () => <TabsDemo isInverted />,
 };

--- a/src/components/tabs/tab.test.tsx
+++ b/src/components/tabs/tab.test.tsx
@@ -14,4 +14,17 @@ describe('<Tabs />', () => {
     const tabs = screen.getByRole('tablist');
     expect(tabs).toBeInTheDocument();
   });
+
+  it('applies inverted background class on TabList', () => {
+    render(
+      <TabList isInverted>
+        <Tab id='one' isActive>
+          One tab
+        </Tab>
+        <Tab id='two'>Second tab</Tab>
+      </TabList>,
+    );
+
+    expect(screen.getByRole('tablist')).toHaveClass('tablist--inverted');
+  });
 });

--- a/src/components/tabs/tab.tsx
+++ b/src/components/tabs/tab.tsx
@@ -61,14 +61,22 @@ export const Tab = ({
 export interface TabListProperties extends HTMLAttributes<HTMLDivElement> {
   className?: string;
   children?: ReactNode;
+  /**
+   * Invert tab backgrounds: inactive tabs use the default gray fill,
+   * active tab uses white. Link colors and other chrome are unchanged.
+   */
+  isInverted?: boolean;
 }
 
 export const TabList = ({
   className,
   children,
+  isInverted = false,
   ...properties
 }: TabListProperties): JSXElement => {
-  const cname = classnames('tablist', className);
+  const cname = classnames('tablist', className, {
+    'tablist--inverted': isInverted,
+  });
 
   return (
     <div role='tablist' className={cname} {...properties}>

--- a/src/components/tabs/tab.tsx
+++ b/src/components/tabs/tab.tsx
@@ -62,8 +62,8 @@ export interface TabListProperties extends HTMLAttributes<HTMLDivElement> {
   className?: string;
   children?: ReactNode;
   /**
-   * Invert tab backgrounds: inactive tabs use the default gray fill,
-   * active tab uses white. Link colors and other chrome are unchanged.
+   * Render tabs without fills. Same chrome as default tabs (active border,
+   * inactive link styles), but transparent backgrounds on every tab.
    */
   isInverted?: boolean;
 }


### PR DESCRIPTION
invert tab backgrounds for pages that need it, like CCDB
Fixed the faint line under active tabs (worse on mobile):
Root cause — heading-4 still added a 10px bottom margin at xs, so the tablist rule sat in a gap below the tab fills.
parent border-bottom didn’t cover cleanly under the active tab; switched to an inset box-shadow, opaque active fills, and zeroed that mobile margin.

Extras — focus ring outline-offset: 2px; 

removed unused eslint-disables in SelectMulti.