### PR TITLE
Indeterminate mixed option

### DIFF
--- a/src/components/checkbox/checkbox.test.tsx
+++ b/src/components/checkbox/checkbox.test.tsx
@@ -106,4 +106,20 @@ describe('Checkbox', () => {
     const checkbox = screen.getByTestId(inputTestId);
     expect(checkbox.matches(':indeterminate')).toBe(true);
   });
+
+  it('sets aria-checked to mixed when isIndeterminate is true', () => {
+    render(<Checkbox {...defaultProps} isIndeterminate />);
+
+    const checkbox = screen.getByTestId(inputTestId);
+    expect(checkbox).toHaveAttribute(attributeAria, 'mixed');
+  });
+
+  it('sets aria-checked to mixed in controlled mode when isIndeterminate is true', () => {
+    render(
+      <Checkbox {...defaultProps} checked={false} isIndeterminate />,
+    );
+
+    const checkbox = screen.getByTestId(inputTestId);
+    expect(checkbox).toHaveAttribute(attributeAria, 'mixed');
+  });
 });

--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -112,6 +112,10 @@ export const Checkbox = ({
     });
   }
 
+  if (isIndeterminate) {
+    Object.assign(inputProperties, { 'aria-checked': 'mixed' });
+  }
+
   useEffect(() => {
     if (typeof ref === 'object' && ref.current !== null) {
       ref.current.indeterminate = isIndeterminate


### PR DESCRIPTION
@virginiacc 
I took a look at the spec for the indeterminate checkbox: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-checked

When isIndeterminate is true, aria-checked should be "mixed" so it isn’t overwritten by the boolean checked value in controlled mode. 

I think this should take care of it.